### PR TITLE
Disable s3 tables catalog cache

### DIFF
--- a/crates/catalog/src/catalog_list.rs
+++ b/crates/catalog/src/catalog_list.rs
@@ -248,7 +248,7 @@ impl EmbucketCatalogList {
             .await
             .context(catalog_error::DataFusionSnafu)?;
         Ok(CachingCatalog::new(Arc::new(catalog), name.to_string())
-            .with_refresh(true)
+            .with_refresh(false)
             .with_catalog_type(CatalogType::S3tables))
     }
 


### PR DESCRIPTION
This is required only to build catalogs tree for UI.
Disabling this flag will speed up service start with connected s3 tables catalog