### PR TITLE
Snowflake iceberg tables adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "http 1.3.1",
  "indexmap 2.12.0",
  "insta",
+ "jsonwebtoken",
  "reqwest",
  "serde",
  "serde_json",
@@ -225,10 +226,12 @@ name = "api-snowflake-rest-sessions"
 version = "0.1.0"
 dependencies = [
  "axum 0.8.6",
+ "chrono",
  "error-stack",
  "error-stack-trace",
  "executor",
  "http 1.3.1",
+ "jsonwebtoken",
  "regex",
  "serde",
  "snafu",
@@ -1546,7 +1549,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2930,8 +2933,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion_iceberg"
-version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=1eeb4515446119dd3b4dbb7ebd2f70ae5b4f827d#1eeb4515446119dd3b4dbb7ebd2f70ae5b4f827d"
+version = "0.9.0"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=b5089dc285667858469a6c2abb297af3d81a03f5#b5089dc285667858469a6c2abb297af3d81a03f5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3263,11 +3266,14 @@ dependencies = [
  "console-subscriber",
  "dotenv",
  "executor",
+ "iceberg-rust",
+ "object_store",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "queries",
  "serde",
+ "serde_json",
  "serde_yaml",
  "snafu",
  "strum 0.27.2",
@@ -4357,8 +4363,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg-rust"
-version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=1eeb4515446119dd3b4dbb7ebd2f70ae5b4f827d#1eeb4515446119dd3b4dbb7ebd2f70ae5b4f827d"
+version = "0.9.0"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=b5089dc285667858469a6c2abb297af3d81a03f5#b5089dc285667858469a6c2abb297af3d81a03f5"
 dependencies = [
  "apache-avro",
  "arrow 56.2.0",
@@ -4393,8 +4399,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg-rust-spec"
-version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=1eeb4515446119dd3b4dbb7ebd2f70ae5b4f827d#1eeb4515446119dd3b4dbb7ebd2f70ae5b4f827d"
+version = "0.9.0"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=b5089dc285667858469a6c2abb297af3d81a03f5#b5089dc285667858469a6c2abb297af3d81a03f5"
 dependencies = [
  "apache-avro",
  "arrow-schema 56.2.0",
@@ -4418,8 +4424,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg-s3tables-catalog"
-version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=1eeb4515446119dd3b4dbb7ebd2f70ae5b4f827d#1eeb4515446119dd3b4dbb7ebd2f70ae5b4f827d"
+version = "0.9.0"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=b5089dc285667858469a6c2abb297af3d81a03f5#b5089dc285667858469a6c2abb297af3d81a03f5"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -4641,15 +4647,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -4707,6 +4704,21 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -5597,6 +5609,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5922,7 +5944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.107",
@@ -6957,6 +6979,18 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.17",
+ "time",
+]
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,15 +44,16 @@ datafusion-expr = { version = "50.0.0" }
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "439cbd2282504c3ffaf262f1ffdb530a0fb1a151" }
 datafusion-macros = { version = "50.0.0" }
 datafusion-physical-plan = { version = "50.0.0" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "1eeb4515446119dd3b4dbb7ebd2f70ae5b4f827d" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "b5089dc285667858469a6c2abb297af3d81a03f5" }
 futures = { version = "0.3" }
 http = "1.2"
 http-body-util = "0.1.0"
 iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev="7a5ad1fcaf00d4638857812bab788105f6c60573"}
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "1eeb4515446119dd3b4dbb7ebd2f70ae5b4f827d" }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "1eeb4515446119dd3b4dbb7ebd2f70ae5b4f827d" }
-iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "1eeb4515446119dd3b4dbb7ebd2f70ae5b4f827d" }
-iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "1eeb4515446119dd3b4dbb7ebd2f70ae5b4f827d" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "b5089dc285667858469a6c2abb297af3d81a03f5" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "b5089dc285667858469a6c2abb297af3d81a03f5" }
+iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "b5089dc285667858469a6c2abb297af3d81a03f5" }
+iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "b5089dc285667858469a6c2abb297af3d81a03f5" }
+
 indexmap = "2.7.1"
 jsonwebtoken = "9.3.1"
 lazy_static = { version = "1.5" }

--- a/crates/api-snowflake-rest-sessions/Cargo.toml
+++ b/crates/api-snowflake-rest-sessions/Cargo.toml
@@ -19,6 +19,8 @@ snafu = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 regex = { workspace = true }
+jsonwebtoken = { workspace = true }
+chrono = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/api-snowflake-rest-sessions/src/error.rs
+++ b/crates/api-snowflake-rest-sessions/src/error.rs
@@ -2,6 +2,7 @@ use axum::{Json, http, response::IntoResponse};
 use error_stack_trace;
 use http::header::InvalidHeaderValue;
 use http::{StatusCode, header::MaxSizeReached};
+use jsonwebtoken::errors::Error as JwtError;
 use serde::{Deserialize, Serialize};
 use snafu::Location;
 use snafu::prelude::*;
@@ -32,6 +33,14 @@ pub enum Error {
     Execution {
         #[snafu(source)]
         error: executor::Error,
+    },
+
+    #[snafu(display("Bad authentication token. {error}"))]
+    BadAuthToken {
+        #[snafu(source)]
+        error: JwtError,
+        #[snafu(implicit)]
+        location: Location,
     },
 }
 

--- a/crates/api-snowflake-rest-sessions/src/helpers.rs
+++ b/crates/api-snowflake-rest-sessions/src/helpers.rs
@@ -1,0 +1,62 @@
+use chrono::offset::Local;
+use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation, decode, encode};
+use serde::{Deserialize, Serialize};
+use time::Duration;
+use uuid::Uuid;
+
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(test, derive(Debug))]
+pub struct Claims {
+    pub sub: String, // token issued to a particular user
+    pub iat: i64,    // Issued At
+    pub exp: i64,    // Expiration Time
+    pub session_id: String,
+}
+
+#[must_use]
+pub fn jwt_claims(username: &str, expiration: Duration) -> Claims {
+    let now = Local::now();
+    let iat = now.timestamp();
+    let exp = now.timestamp() + expiration.whole_seconds();
+
+    Claims {
+        sub: username.to_string(),
+        iat,
+        exp,
+        session_id: Uuid::new_v4().to_string(),
+    }
+}
+
+pub fn get_claims_validate_jwt_token(
+    token: &str,
+    jwt_secret: &str,
+) -> Result<Claims, jsonwebtoken::errors::Error> {
+    let mut validation = Validation::default();
+    validation.leeway = 5;
+    validation.set_required_spec_claims(&["exp"]);
+
+    let decoding_key = DecodingKey::from_secret(jwt_secret.as_bytes());
+
+    let decoded = decode::<Claims>(token, &decoding_key, &validation)?;
+
+    Ok(decoded.claims)
+}
+
+pub fn create_jwt<T>(claims: &T, jwt_secret: &str) -> Result<String, jsonwebtoken::errors::Error>
+where
+    T: Serialize,
+{
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(jwt_secret.as_bytes()),
+    )
+}
+
+#[must_use]
+pub fn ensure_jwt_secret_is_valid(jwt_secret: &str) -> Option<String> {
+    if jwt_secret.is_empty() {
+        return None;
+    }
+    Some(jwt_secret.to_string())
+}

--- a/crates/api-snowflake-rest-sessions/src/lib.rs
+++ b/crates/api-snowflake-rest-sessions/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod error;
+pub mod helpers;
 pub mod layer;
 pub mod session;
 

--- a/crates/api-snowflake-rest/Cargo.toml
+++ b/crates/api-snowflake-rest/Cargo.toml
@@ -51,6 +51,7 @@ time = { workspace = true }
 uuid = { workspace = true }
 tokio = { workspace = true }
 cfg-if = { workspace = true }
+jsonwebtoken = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/api-snowflake-rest/src/models.rs
+++ b/crates/api-snowflake-rest/src/models.rs
@@ -141,4 +141,15 @@ impl From<ColumnInfoModel> for ColumnInfo {
 pub struct Auth {
     pub demo_user: String,
     pub demo_password: String,
+    pub jwt_secret: String,
+}
+
+impl Auth {
+    #[must_use]
+    pub fn new(jwt_secret: String) -> Self {
+        Self {
+            jwt_secret,
+            ..Self::default()
+        }
+    }
 }

--- a/crates/api-snowflake-rest/src/server/error.rs
+++ b/crates/api-snowflake-rest/src/server/error.rs
@@ -6,10 +6,11 @@ use datafusion::arrow::error::ArrowError;
 use error_stack::ErrorChainExt;
 use error_stack::ErrorExt;
 use error_stack_trace;
-use executor::QueryRecordId;
+use executor::QueryId;
 use executor::error::OperationOn;
 use executor::error_code::ErrorCode;
 use executor::snowflake_error::Entity;
+use jsonwebtoken::errors::Error as JwtError;
 use snafu::Location;
 use snafu::prelude::*;
 
@@ -70,6 +71,28 @@ pub enum Error {
 
     #[snafu(transparent)]
     Execution { source: executor::Error },
+
+    #[snafu(display("JWT secret is not set"))]
+    NoJwtSecret {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Failed to create JWT: {error}"))]
+    CreateJwt {
+        #[snafu(source)]
+        error: JwtError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Bad authentication token. {error}"))]
+    BadAuthToken {
+        #[snafu(source)]
+        error: JwtError,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 impl IntoResponse for Error {
@@ -109,11 +132,11 @@ impl Error {
         InvalidAuthDataSnafu.build()
     }
 
-    pub fn query_id(&self) -> QueryRecordId {
+    pub fn query_id(&self) -> QueryId {
         if let Self::Execution { source, .. } = self {
             source.query_id()
         } else {
-            QueryRecordId::default()
+            QueryId::default()
         }
     }
 
@@ -190,7 +213,10 @@ impl Error {
             }
             Self::MissingAuthToken { .. }
             | Self::InvalidAuthData { .. }
-            | Self::InvalidAuthToken { .. } => (
+            | Self::InvalidAuthToken { .. }
+            | Self::NoJwtSecret { .. }
+            | Self::CreateJwt { .. }
+            | Self::BadAuthToken { .. } => (
                 http::StatusCode::UNAUTHORIZED,
                 SqlState::Success,
                 ErrorCode::Other,
@@ -210,8 +236,7 @@ impl Error {
         tracing::Span::current()
             .record("error_code", error_code.to_string())
             .record("sql_state", sql_state.to_string())
-            .record("query_id", self.query_id().as_i64())
-            .record("query_uuid", self.query_id().as_uuid().to_string())
+            .record("query_id", self.query_id().to_string())
             .record("display_error", &display_error)
             .record("debug_error", self.debug_error_message())
             .record("error_stack_trace", self.output_msg())
@@ -234,7 +259,7 @@ impl Error {
                 returned: None,
                 query_result_format: None,
                 // Query uuid is returned to the user
-                query_id: Some(self.query_id().as_uuid().to_string()),
+                query_id: Some(self.query_id().to_string()),
             }),
             code: Some(error_code.to_string()),
         });

--- a/crates/api-snowflake-rest/src/server/handlers.rs
+++ b/crates/api-snowflake-rest/src/server/handlers.rs
@@ -34,7 +34,7 @@ pub async fn login(
     name = "api_snowflake_rest::query",
     level = "debug",
     skip(state),
-    fields(query_id, query_uuid),
+    fields(query_id),
     err,
     ret(level = tracing::Level::TRACE),
 )]
@@ -65,9 +65,10 @@ pub async fn abort(
         request_id,
     }): Json<AbortRequestBody>,
 ) -> Result<Json<serde_json::value::Value>> {
-    state
+    let query_id = state
         .execution_svc
-        .abort_query(RunningQueryId::ByRequestId(request_id, sql_text))?;
+        .locate_query_id(RunningQueryId::ByRequestId(request_id, sql_text))?;
+    state.execution_svc.abort(query_id)?;
     Ok(Json(serde_json::value::Value::Null))
 }
 

--- a/crates/api-snowflake-rest/src/server/helpers.rs
+++ b/crates/api-snowflake-rest/src/server/helpers.rs
@@ -14,6 +14,7 @@ use executor::utils::{
 };
 use serde_json::value::RawValue;
 use snafu::ResultExt;
+use tracing;
 use uuid::Uuid;
 
 // https://arrow.apache.org/docs/format/Columnar.html#buffer-alignment-and-padding
@@ -73,7 +74,7 @@ fn records_to_json_string(recs: &[RecordBatch]) -> std::result::Result<String, E
 )]
 pub fn handle_query_ok_result(
     sql_text: &str,
-    query_uuid: Uuid,
+    query_id: Uuid,
     query_result: QueryResult,
     ser_fmt: DataSerializationFormat,
 ) -> Result<JsonResponse> {
@@ -114,7 +115,7 @@ pub fn handle_query_ok_result(
             row_set_base_64,
             total: Some(total_rows),
             returned: Some(returned_rows),
-            query_id: Some(query_uuid.to_string()),
+            query_id: Some(query_id.to_string()),
             error_code: None,
             sql_state: Some(SqlState::Success.to_string()),
         }),

--- a/crates/api-snowflake-rest/src/server/server_models.rs
+++ b/crates/api-snowflake-rest/src/server/server_models.rs
@@ -8,10 +8,10 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn new(data_format: &str) -> std::result::Result<Self, strum::ParseError> {
+    pub fn new(data_format: &str, jwt_secret: String) -> Result<Self, strum::ParseError> {
         Ok(Self {
             dbt_serialization_format: DataSerializationFormat::try_from(data_format)?,
-            ..Self::default()
+            auth: Auth::new(jwt_secret),
         })
     }
     #[must_use]
@@ -19,6 +19,7 @@ impl Config {
         self.auth = Auth {
             demo_user,
             demo_password,
+            ..self.auth
         };
         self
     }

--- a/crates/api-snowflake-rest/src/server/state.rs
+++ b/crates/api-snowflake-rest/src/server/state.rs
@@ -1,4 +1,5 @@
 use super::server_models::Config;
+use api_snowflake_rest_sessions::session::JwtSecret;
 use executor::ExecutionAppState;
 use executor::service::ExecutionService;
 use std::sync::Arc;
@@ -12,5 +13,11 @@ pub struct AppState {
 impl ExecutionAppState for AppState {
     fn get_execution_svc(&self) -> Arc<dyn ExecutionService> {
         self.execution_svc.clone()
+    }
+}
+
+impl JwtSecret for AppState {
+    fn jwt_secret(&self) -> &str {
+        self.config.auth.jwt_secret.as_str()
     }
 }

--- a/crates/api-snowflake-rest/src/server/test_server.rs
+++ b/crates/api-snowflake-rest/src/server/test_server.rs
@@ -8,7 +8,7 @@ use tracing_subscriber::fmt::format::FmtSpan;
 
 #[allow(clippy::expect_used)]
 pub async fn run_test_rest_api_server(data_format: &str) -> SocketAddr {
-    let app_cfg = Config::new(data_format)
+    let app_cfg = Config::new(data_format, "embucket".to_string())
         .expect("Failed to create server config")
         .with_demo_credentials("embucket".to_string(), "embucket".to_string());
 

--- a/crates/catalog/src/catalogs/embucket/schema.rs
+++ b/crates/catalog/src/catalogs/embucket/schema.rs
@@ -1,4 +1,5 @@
 use crate::block_in_new_runtime;
+use crate::snowflake_table::SnowflakeCaseInsensitiveTable;
 use async_trait::async_trait;
 use catalog_metastore::error as metastore_error;
 use catalog_metastore::{Metastore, SchemaIdent, TableIdent};
@@ -92,8 +93,11 @@ impl SchemaProvider for EmbucketSchema {
                 .await
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
                 let tabular = IcebergTabular::Table(iceberg_table);
+
                 let table_provider: Arc<dyn TableProvider> =
-                    Arc::new(IcebergDataFusionTable::new(tabular, None, None, None));
+                    Arc::new(SnowflakeCaseInsensitiveTable::new(Arc::new(
+                        IcebergDataFusionTable::new(tabular, None, None, None),
+                    )));
                 Ok(Some(table_provider))
             }
             Ok(None) => Ok(None),

--- a/crates/catalog/src/lib.rs
+++ b/crates/catalog/src/lib.rs
@@ -10,6 +10,7 @@ pub mod df_error;
 pub mod error;
 pub mod information_schema;
 pub mod schema;
+pub mod snowflake_table;
 pub mod table;
 
 #[cfg(test)]

--- a/crates/catalog/src/schema.rs
+++ b/crates/catalog/src/schema.rs
@@ -1,13 +1,17 @@
 use crate::df_error;
-use crate::table::CachingTable;
+use crate::snowflake_table::SnowflakeCaseInsensitiveTable;
+use crate::table::{CachingTable, IcebergTableBuilder};
 use async_trait::async_trait;
 use dashmap::DashMap;
 use datafusion::catalog::{SchemaProvider, TableProvider};
 use datafusion_common::DataFusionError;
 use datafusion_expr::TableType;
+use datafusion_iceberg::DataFusionTable;
 use futures::executor::block_on;
 use iceberg_rust::catalog::Catalog;
+use iceberg_rust::catalog::tabular::Tabular as IcebergTabular;
 use iceberg_rust_spec::identifier::Identifier;
+use snafu::ResultExt;
 use snafu::futures::TryFutureExt;
 use std::any::Any;
 use std::sync::Arc;
@@ -81,12 +85,31 @@ impl SchemaProvider for CachingSchema {
         name: String,
         table: Arc<dyn TableProvider>,
     ) -> datafusion_common::Result<Option<Arc<dyn TableProvider>>> {
-        let caching_table = Arc::new(CachingTable::new(name.clone(), Arc::clone(&table)));
-        self.tables_cache.insert(name.clone(), caching_table);
-        if table.table_type() != TableType::View {
-            return self.schema.register_table(name, table);
-        }
-        Ok(Some(table))
+        let table_provider: Arc<dyn TableProvider> = if let Some(catalog) = &self.iceberg_catalog
+            && let Some(iceberg_builder) = table.as_any().downcast_ref::<IcebergTableBuilder>()
+            && table.table_type() != TableType::View
+        {
+            let ident = Identifier::new(std::slice::from_ref(&self.name), &name);
+            block_on(async move {
+                let mut builder = iceberg_builder.builder.clone();
+                let iceberg_table = builder
+                    .build(ident.namespace(), catalog.clone())
+                    .await
+                    .context(df_error::IcebergSnafu)?;
+                let tabular = IcebergTabular::Table(iceberg_table);
+                let table_provider: Arc<dyn TableProvider> =
+                    Arc::new(SnowflakeCaseInsensitiveTable::new(Arc::new(
+                        DataFusionTable::new(tabular, None, None, None),
+                    )));
+                Ok::<Arc<dyn TableProvider>, DataFusionError>(table_provider)
+            })?
+        } else {
+            table
+        };
+
+        let caching_table = Arc::new(CachingTable::new(name.clone(), Arc::clone(&table_provider)));
+        self.tables_cache.insert(name, caching_table);
+        Ok(Some(table_provider))
     }
 
     #[allow(clippy::as_conversions)]

--- a/crates/catalog/src/snowflake_table.rs
+++ b/crates/catalog/src/snowflake_table.rs
@@ -1,0 +1,152 @@
+use async_trait::async_trait;
+use datafusion::arrow::datatypes::{Schema, SchemaRef};
+use datafusion::catalog::{Session, TableProvider};
+use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
+use datafusion_common::{Statistics, project_schema};
+use datafusion_expr::dml::InsertOp;
+use datafusion_expr::{Expr, TableProviderFilterPushDown, TableType};
+use datafusion_physical_plan::expressions::Column;
+use datafusion_physical_plan::projection::ProjectionExec;
+use datafusion_physical_plan::{ExecutionPlan, PhysicalExpr};
+use std::any::Any;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+/// A [`TableProvider`] adapter that rewrites column names to match Snowflake's
+/// case-insensitive semantics.
+///
+/// Snowflake stores schemas in uppercase, while queries are typically written
+/// in lowercase. `DataFusion` treats identifiers as case-sensitive, which causes
+/// mismatches between the logical projection expressions (lowercase) and the
+/// physical input schema (uppercase). This adapter:
+///
+/// - Rewrites column references in filter expressions to the original schema
+///   casing before delegating to the underlying table provider.
+/// - Wraps the produced physical plan in a projection that aliases columns to
+///   lowercase names, so the output schema matches the logical expectations.
+#[derive(Debug)]
+pub struct SnowflakeCaseInsensitiveTable {
+    inner: Arc<dyn TableProvider>,
+    original_schema: SchemaRef,
+    normalized_schema: SchemaRef,
+}
+
+impl SnowflakeCaseInsensitiveTable {
+    pub fn new(inner: Arc<dyn TableProvider>) -> Self {
+        let original_schema = inner.schema();
+        let normalized_schema = Arc::new(Schema::new(
+            original_schema
+                .fields()
+                .iter()
+                .map(|field| {
+                    let mut cloned = field.as_ref().clone();
+                    cloned.set_name(field.name().to_ascii_lowercase());
+                    cloned
+                })
+                .collect::<Vec<_>>(),
+        ));
+        Self {
+            inner,
+            original_schema,
+            normalized_schema,
+        }
+    }
+
+    fn rewrite_expr(&self, expr: Expr) -> datafusion_common::Result<Expr> {
+        expr.transform_up(|e| {
+            if let Expr::Column(col) = &e {
+                let lookup = self
+                    .original_schema
+                    .fields()
+                    .iter()
+                    .find(|field| field.name().eq_ignore_ascii_case(&col.name));
+
+                if let Some(field) = lookup {
+                    let mut updated = col.clone();
+                    updated.name.clone_from(field.name());
+                    return Ok(Transformed::yes(Expr::Column(updated)));
+                }
+            }
+            Ok(Transformed::no(e))
+        })
+        .data()
+    }
+}
+
+#[async_trait]
+impl TableProvider for SnowflakeCaseInsensitiveTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.normalized_schema)
+    }
+
+    fn table_type(&self) -> TableType {
+        self.inner.table_type()
+    }
+
+    #[allow(clippy::as_conversions)]
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+        let rewritten_filters = filters
+            .iter()
+            .map(|expr| self.rewrite_expr(expr.clone()))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let plan = self
+            .inner
+            .scan(state, projection, &rewritten_filters, limit)
+            .await?;
+
+        let target_schema = if let Some(indices) = projection {
+            project_schema(&self.normalized_schema, Some(indices))?
+        } else {
+            Arc::clone(&self.normalized_schema)
+        };
+
+        let mut projection_exprs = Vec::with_capacity(plan.schema().fields().len());
+        for (idx, field) in plan.schema().fields().iter().enumerate() {
+            let target_name = target_schema.field(idx).name().clone();
+
+            projection_exprs.push((
+                Arc::new(Column::new(field.name(), idx)) as Arc<dyn PhysicalExpr>,
+                target_name,
+            ));
+        }
+
+        let projected_plan = ProjectionExec::try_new(projection_exprs, plan)?;
+        Ok(Arc::new(projected_plan))
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> datafusion_common::Result<Vec<TableProviderFilterPushDown>> {
+        let rewritten = filters
+            .iter()
+            .map(|expr| self.rewrite_expr((*expr).clone()))
+            .collect::<Result<Vec<_>, _>>()?;
+        let rewritten_refs = rewritten.iter().collect::<Vec<_>>();
+        self.inner.supports_filters_pushdown(&rewritten_refs)
+    }
+
+    fn statistics(&self) -> Option<Statistics> {
+        self.inner.statistics()
+    }
+
+    async fn insert_into(
+        &self,
+        state: &dyn Session,
+        input: Arc<dyn ExecutionPlan>,
+        insert_op: InsertOp,
+    ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+        self.inner.insert_into(state, input, insert_op).await
+    }
+}

--- a/crates/embucket-lambda/Cargo.toml
+++ b/crates/embucket-lambda/Cargo.toml
@@ -28,3 +28,25 @@ tower-http = { workspace = true }
 
 [lints]
 workspace = true
+
+[[bin]]
+name = "bootstrap"
+path = "src/main.rs"
+
+[package.metadata.lambda]
+# Default binary to deploy
+default-binary = "bootstrap"
+
+[package.metadata.lambda.deploy]
+# Function name: Can be set via CARGO_LAMBDA_FUNCTION_NAME env var
+# If not set, falls back to binary name or pass as CLI argument
+memory = 3008
+timeout = 30
+tracing = "Active"
+# Note: include path is relative to workspace root
+# Must run deploy from workspace root: cargo lambda deploy --binary-name bootstrap
+include = ["config"]
+
+[package.metadata.lambda.deploy.env]
+LOG_FORMAT = "json"
+METASTORE_CONFIG = "config/metastore.yaml"

--- a/crates/embucket-lambda/Makefile
+++ b/crates/embucket-lambda/Makefile
@@ -1,0 +1,36 @@
+.PHONY: build deploy test logs clean
+
+# Function name (override with: make deploy FUNCTION_NAME=your-function)
+FUNCTION_NAME ?= embucket-lambda
+
+# Build the lambda function
+build:
+	cd ../.. && cargo lambda build --release --arm64 --manifest-path crates/embucket-lambda/Cargo.toml
+
+# Deploy to AWS (must run from workspace root for include paths to work)
+deploy: build
+	cd ../.. && cargo lambda deploy --binary-name bootstrap $(FUNCTION_NAME)
+
+# Quick deploy without rebuild
+deploy-only:
+	cd ../.. && cargo lambda deploy --binary-name bootstrap $(FUNCTION_NAME)
+
+# Watch locally for development
+watch:
+	cargo lambda watch
+
+# Test with a local event
+test:
+	cargo lambda invoke --data-file test-event.json
+
+# Tail lambda logs
+logs:
+	aws logs tail /aws/lambda/embucket-lambda --since 5m --follow
+
+# Verify deployment with snow CLI
+verify:
+	snow sql -c lambda -q "SELECT 1 as test_column"
+
+# Clean build artifacts
+clean:
+	cargo clean

--- a/crates/embucket-lambda/README.md
+++ b/crates/embucket-lambda/README.md
@@ -1,0 +1,105 @@
+# Embucket Lambda
+
+AWS Lambda function for Embucket using cargo-lambda.
+
+## Configuration
+
+The Lambda function is configured using:
+- `Cargo.toml`: Package metadata for build and deployment settings (memory, timeout, env vars, included files)
+- `Makefile`: Function name and deployment shortcuts (easily customizable)
+- `.envrc`: (Optional) Environment variables for direnv users
+
+## Usage
+
+### Quick Start with Makefile
+
+```bash
+cd crates/embucket-lambda
+
+# Build and deploy (function name from Makefile)
+make deploy
+
+# Deploy to a different function
+make deploy FUNCTION_NAME=my-other-function
+
+# Deploy without rebuilding
+make deploy-only
+
+# Verify deployment
+make verify
+
+# Watch logs
+make logs
+```
+
+The function name defaults to `embucket-lambda` but can be overridden:
+- Via Makefile variable: `make deploy FUNCTION_NAME=my-function`
+- Via environment variable: `export FUNCTION_NAME=my-function && make deploy`
+
+### Manual Commands
+
+All commands should be run from the **workspace root** (`/Users/ramp/vcs/embucket`):
+
+```bash
+# Build the Lambda function
+cargo lambda build --release --arm64 --manifest-path crates/embucket-lambda/Cargo.toml
+
+# Deploy to AWS (function name and config are in Cargo.toml)
+cargo lambda deploy --binary-name bootstrap
+
+# The deployment automatically:
+# - Deploys to function "embucket-lambda" (from Cargo.toml)
+# - Includes the config directory (from Cargo.toml)
+# - Applies all settings: memory, timeout, env vars (from Cargo.toml)
+```
+
+**Important**: Due to workspace structure, you still need to specify `--binary-name bootstrap`.
+
+### Customization
+
+**Function Name**: Set via:
+1. Positional argument: `cargo lambda deploy --binary-name bootstrap my-function-name`
+2. Makefile variable: `FUNCTION_NAME=my-function` (default: `embucket-lambda`)
+3. Environment variable: `export CARGO_LAMBDA_FUNCTION_NAME=my-function` (if supported by your cargo-lambda version)
+
+**IAM Role**: Only needed when creating a NEW function. For existing functions, the role is preserved.
+- To specify: `export AWS_LAMBDA_ROLE_ARN=arn:aws:iam::account:role/YourRole`
+
+**Other Settings** (in `Cargo.toml`):
+- Memory: `memory = 3008`
+- Timeout: `timeout = 30`
+- Environment variables: `[package.metadata.lambda.deploy.env]`
+- Included files: `include = ["config"]`
+
+### Test locally
+
+```bash
+# Start the function locally
+cargo lambda watch
+
+# In another terminal, invoke it
+cargo lambda invoke --data-file test-event.json
+```
+
+### Verify deployment
+
+```bash
+# Using snow CLI
+snow sql -c lambda -q "SELECT 1 as test_column"
+
+# Using curl
+curl -X POST https://<function-url>.lambda-url.us-east-2.on.aws/session/v1/login-request \
+  -H "Content-Type: application/json" \
+  -d '{"data": {"ACCOUNT_NAME": "account", "LOGIN_NAME": "embucket", "PASSWORD": "embucket", "CLIENT_APP_ID": "test"}}'
+
+# Check logs
+aws logs tail /aws/lambda/embucket-lambda --since 5m --follow
+```
+
+## Environment Variables
+
+- `LOG_FORMAT`: json
+- `METASTORE_CONFIG`: config/metastore.yaml
+- `RUST_LOG`: (optional) Set logging level, defaults to "info"
+
+

--- a/crates/embucket-lambda/src/config.rs
+++ b/crates/embucket-lambda/src/config.rs
@@ -17,6 +17,7 @@ pub struct EnvConfig {
     pub bootstrap_default_entities: bool,
     pub embucket_version: String,
     pub metastore_config: Option<PathBuf>,
+    pub jwt_secret: Option<String>,
 }
 
 impl EnvConfig {
@@ -38,6 +39,7 @@ impl EnvConfig {
             bootstrap_default_entities: !env_bool("NO_BOOTSTRAP"),
             embucket_version: env_or_default("EMBUCKET_VERSION", "0.1.0"),
             metastore_config: env::var("METASTORE_CONFIG").ok().map(PathBuf::from),
+            jwt_secret: env::var("JWT_SECRET").ok(),
         }
     }
 

--- a/crates/embucket-lambda/src/main.rs
+++ b/crates/embucket-lambda/src/main.rs
@@ -3,21 +3,17 @@ mod metastore_config;
 
 use crate::config::EnvConfig;
 use crate::metastore_config::MetastoreBootstrapConfig;
-use api_snowflake_rest::server::error::Error as SnowflakeError;
 use api_snowflake_rest::server::layer::require_auth;
 use api_snowflake_rest::server::router::{create_auth_router, create_router};
 use api_snowflake_rest::server::server_models::Config as SnowflakeServerConfig;
 use api_snowflake_rest::server::state::AppState;
-use api_snowflake_rest_sessions::session::{
-    SESSION_EXPIRATION_SECONDS, SessionStore, extract_token_from_auth,
-};
+use api_snowflake_rest_sessions::session::{SESSION_EXPIRATION_SECONDS, SessionStore};
 use axum::body::Body as AxumBody;
 use axum::extract::connect_info::ConnectInfo;
 use axum::{Router, middleware};
 use catalog_metastore::InMemoryMetastore;
 use executor::service::CoreExecutionService;
-use http::header::{AUTHORIZATION, CONTENT_TYPE};
-use http::{HeaderMap, HeaderValue};
+use http::HeaderMap;
 use http_body_util::BodyExt;
 use lambda_http::{Body as LambdaBody, Error as LambdaError, Request, Response, run, service_fn};
 use std::io::IsTerminal;
@@ -28,7 +24,6 @@ use tower::{ServiceBuilder, ServiceExt};
 use tower_http::compression::CompressionLayer;
 use tower_http::decompression::RequestDecompressionLayer;
 use tracing::{error, info};
-use uuid::Uuid;
 
 type InitResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
@@ -67,8 +62,16 @@ struct LambdaApp {
 }
 
 impl LambdaApp {
+    #[tracing::instrument(name = "lambda_app_initialize", skip_all, fields(
+        data_format = %config.data_format,
+        max_concurrency = config.max_concurrency_level
+    ))]
     async fn initialize(config: EnvConfig) -> InitResult<Self> {
-        let snowflake_cfg = SnowflakeServerConfig::new(&config.data_format)?.with_demo_credentials(
+        let snowflake_cfg = SnowflakeServerConfig::new(
+            &config.data_format,
+            config.jwt_secret.clone().unwrap_or_default(),
+        )?
+        .with_demo_credentials(
             config.auth_demo_user.clone(),
             config.auth_demo_password.clone(),
         );
@@ -125,24 +128,36 @@ impl LambdaApp {
         Ok(Self { router, state })
     }
 
+    #[tracing::instrument(name = "lambda_handle_event", skip_all, fields(
+        http.method = %request.method(),
+        http.uri = %request.uri(),
+        http.request_id = tracing::field::Empty,
+        http.status_code = tracing::field::Empty
+    ))]
     async fn handle_event(&self, request: Request) -> Result<Response<LambdaBody>, LambdaError> {
-        let (mut parts, body) = request.into_parts();
+        let (parts, body) = request.into_parts();
         let body_bytes = lambda_body_into_bytes(body);
 
         {
-            let body_preview = String::from_utf8_lossy(&body_bytes);
+            let body_size = body_bytes.len();
+            let is_compressed = parts
+                .headers
+                .get("content-encoding")
+                .and_then(|v| v.to_str().ok())
+                .is_some_and(|v| v.contains("gzip"));
+
             info!(
                 method = %parts.method,
                 uri = %parts.uri,
-                headers = ?parts.headers,
-                body = %body_preview,
+                body_size_bytes = body_size,
+                body_compressed = is_compressed,
                 "Received incoming HTTP request"
             );
         }
 
-        if let Err(err) = ensure_session_header(&mut parts.headers, &self.state).await {
-            return Ok(snowflake_error_response(&err));
-        }
+        // if let Err(err) = ensure_session_header(&mut parts.headers, &self.state).await {
+        //     return Ok(snowflake_error_response(&err));
+        // }
 
         let mut axum_request = to_axum_request(parts, body_bytes);
         if let Some(addr) = extract_socket_addr(axum_request.headers()) {
@@ -156,7 +171,12 @@ impl LambdaApp {
             .await
             .expect("Router service should be infallible");
 
-        from_axum_response(response).await
+        let lambda_response = from_axum_response(response).await?;
+
+        // Record response status in the current span
+        tracing::Span::current().record("http.status_code", lambda_response.status().as_u16());
+
+        Ok(lambda_response)
     }
 }
 
@@ -181,12 +201,18 @@ async fn from_axum_response(
         .await
         .map_err(|err| -> LambdaError { Box::new(err) })?
         .to_bytes();
-    let body_preview = String::from_utf8_lossy(bytes.as_ref());
+
+    let body_size = bytes.len();
+    let is_compressed = parts
+        .headers
+        .get("content-encoding")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.contains("gzip"));
 
     info!(
         status = %parts.status,
-        headers = ?parts.headers,
-        body = %body_preview,
+        body_size_bytes = body_size,
+        body_compressed = is_compressed,
         "Sending HTTP response"
     );
 
@@ -205,59 +231,79 @@ fn extract_socket_addr(headers: &HeaderMap) -> Option<SocketAddr> {
         .map(|ip| SocketAddr::new(ip, 0))
 }
 
-async fn ensure_session_header(
-    headers: &mut HeaderMap,
-    state: &AppState,
-) -> Result<(), SnowflakeError> {
-    if let Some(token) = extract_token_from_auth(headers) {
-        ensure_session(state, &token).await
-    } else {
-        let session_id = Uuid::new_v4().to_string();
-        state.execution_svc.create_session(&session_id).await?;
-        let header_value = HeaderValue::from_str(&format!("Snowflake Token=\"{session_id}\""))
-            .map_err(|_| SnowflakeError::invalid_auth_data())?;
-        headers.insert(AUTHORIZATION, header_value);
-        Ok(())
-    }
-}
-
-async fn ensure_session(state: &AppState, session_id: &str) -> Result<(), SnowflakeError> {
-    if !state
-        .execution_svc
-        .update_session_expiry(session_id)
-        .await?
-    {
-        let _ = state.execution_svc.create_session(session_id).await?;
-    }
-    Ok(())
-}
-
-fn snowflake_error_response(err: &SnowflakeError) -> Response<LambdaBody> {
-    let (status, axum::Json(body)) = err.prepare_response();
-    let payload =
-        serde_json::to_string(&body).unwrap_or_else(|_| "{\"success\":false}".to_string());
-    let body_preview = payload.clone();
-    let mut response = Response::new(LambdaBody::Text(payload));
-    *response.status_mut() = status;
-    response
-        .headers_mut()
-        .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-    info!(
-        status = %response.status(),
-        headers = ?response.headers(),
-        body = %body_preview,
-        "Sending HTTP error response"
-    );
-    response
-}
+// #[tracing::instrument(name = "ensure_session_header", skip_all)]
+// async fn ensure_session_header(
+//     headers: &mut HeaderMap,
+//     state: &AppState,
+// ) -> Result<(), SnowflakeError> {
+//     if let Some(token) = extract_token_from_auth(headers) {
+//         ensure_session(state, &token).await
+//     } else {
+//         let session_id = Uuid::new_v4().to_string();
+//         state.execution_svc.create_session(&session_id).await?;
+//         let header_value = HeaderValue::from_str(&format!("Snowflake Token=\"{session_id}\""))
+//             .map_err(|_| SnowflakeError::invalid_auth_data())?;
+//         headers.insert(AUTHORIZATION, header_value);
+//         Ok(())
+//     }
+// }
+//
+// #[tracing::instrument(name = "ensure_session", skip(state), fields(session_id = %session_id))]
+// async fn ensure_session(state: &AppState, session_id: &str) -> Result<(), SnowflakeError> {
+//     if !state
+//         .execution_svc
+//         .update_session_expiry(session_id)
+//         .await?
+//     {
+//         let _ = state.execution_svc.create_session(session_id).await?;
+//     }
+//     Ok(())
+// }
+//
+// fn snowflake_error_response(err: &SnowflakeError) -> Response<LambdaBody> {
+//     let (status, axum::Json(body)) = err.prepare_response();
+//     let payload =
+//         serde_json::to_string(&body).unwrap_or_else(|_| "{\"success\":false}".to_string());
+//     let body_preview = payload.clone();
+//     let mut response = Response::new(LambdaBody::Text(payload));
+//     *response.status_mut() = status;
+//     response
+//         .headers_mut()
+//         .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+//     info!(
+//         status = %response.status(),
+//         headers = ?response.headers(),
+//         body = %body_preview,
+//         "Sending HTTP error response"
+//     );
+//     response
+// }
 
 fn init_tracing() {
     let filter = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
     let emit_ansi = std::io::stdout().is_terminal();
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .with_target(true)
-        .with_ansi(emit_ansi)
-        .compact()
-        .try_init();
+
+    // Use json format if requested via env var, otherwise use pretty format with span events
+    let format = std::env::var("LOG_FORMAT").unwrap_or_else(|_| "pretty".to_string());
+
+    if format == "json" {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_target(true)
+            .with_ansi(false)
+            .json()
+            .with_current_span(true)
+            .with_span_list(true)
+            .try_init();
+    } else {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_target(true)
+            .with_ansi(emit_ansi)
+            .with_span_events(
+                tracing_subscriber::fmt::format::FmtSpan::ENTER
+                    | tracing_subscriber::fmt::format::FmtSpan::CLOSE,
+            )
+            .try_init();
+    }
 }

--- a/crates/embucketd/Cargo.toml
+++ b/crates/embucketd/Cargo.toml
@@ -19,6 +19,8 @@ tracing-subscriber = { version = "0.3.20", features = ["env-filter", "registry",
 tracing-opentelemetry = { version = "0.31.0" }
 tracing-allocations = { version = "0.1.0", optional = true }
 tracing-core = { version = "0.1.34"}
+object_store = { workspace = true }
+iceberg-rust = { workspace = true }
 opentelemetry-otlp = { version = "0.30.0", features = ["grpc-tonic"] }
 opentelemetry_sdk = { version = "0.30.0", features = [
     "experimental_trace_batch_span_processor_with_async_runtime",
@@ -36,6 +38,7 @@ utoipa-swagger-ui = { workspace = true }
 strum.workspace = true
 serde_yaml = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 snafu = { workspace = true }
 
 [lints]

--- a/crates/embucketd/src/cli.rs
+++ b/crates/embucketd/src/cli.rs
@@ -160,6 +160,25 @@ pub struct CliOpts {
         help = "Service idle timeout in seconds"
     )]
     pub timeout: Option<u64>,
+
+    // should unset JWT_SECRET env var after loading
+    #[arg(
+        long,
+        env = "JWT_SECRET",
+        hide_env_values = true,
+        help = "JWT secret for auth"
+    )]
+    jwt_secret: Option<String>,
+}
+
+impl CliOpts {
+    // method resets a secret env
+    pub fn jwt_secret(&self) -> String {
+        unsafe {
+            std::env::remove_var("JWT_SECRET");
+        }
+        self.jwt_secret.clone().unwrap_or_default()
+    }
 }
 
 #[derive(Debug, Clone, ValueEnum)]

--- a/crates/embucketd/src/main.rs
+++ b/crates/embucketd/src/main.rs
@@ -121,7 +121,7 @@ async fn async_main(
         .data_format
         .clone()
         .unwrap_or_else(|| "json".to_string());
-    let snowflake_rest_cfg = Config::new(&data_format)
+    let snowflake_rest_cfg = Config::new(&data_format, opts.jwt_secret())
         .expect("Failed to create snowflake config")
         .with_demo_credentials(
             opts.auth_demo_user.clone().unwrap(),

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -17,7 +17,7 @@ pub mod utils;
 pub mod tests;
 
 pub use error::{Error, Result};
-pub use query_types::{QueryRecordId, QueryStatus};
+pub use query_types::{QueryId, QueryStatus};
 pub use running_queries::RunningQueryId;
 pub use snowflake_error::SnowflakeError;
 

--- a/crates/executor/src/query.rs
+++ b/crates/executor/src/query.rs
@@ -1,13 +1,11 @@
+use super::catalog::catalog_list::EmbucketCatalogList;
 use super::catalog::information_schema::information_schema::{
     INFORMATION_SCHEMA, InformationSchemaProvider,
-};
-use super::catalog::{
-    catalog_list::EmbucketCatalogList, catalogs::embucket::catalog::EmbucketCatalog,
 };
 use super::datafusion::planner::ExtendedSqlToRel;
 use super::error::{
     self as ex_error, Error, InvalidColumnIdentifierSnafu, MergeSourceNotSupportedSnafu,
-    ObjectType as ExistingObjectType, RefreshCatalogListSnafu, Result,
+    ObjectType as ExistingObjectType, Result,
 };
 use super::running_queries::RunningQueries;
 use super::session::UserSession;
@@ -20,9 +18,7 @@ use crate::datafusion::physical_plan::merge::{
 use crate::datafusion::rewriters::session_context::SessionContextExprRewriter;
 use crate::error::{OperationOn, OperationType};
 use crate::models::{QueryContext, QueryResult};
-use catalog::catalog::CachingCatalog;
-use catalog::catalog_list::CachedEntity;
-use catalog::table::CachingTable;
+use catalog::table::{CachingTable, IcebergTableBuilder};
 use catalog_metastore::{
     AwsAccessKeyCredentials, AwsCredentials, FileVolume, Metastore, S3TablesVolume, S3Volume,
     TableCreateRequest as MetastoreTableCreateRequest, TableFormat as MetastoreTableFormat,
@@ -32,8 +28,8 @@ use catalog_metastore::{
 use datafusion::arrow::array::{Int64Array, RecordBatch, StringArray};
 use datafusion::arrow::datatypes::{DataType, Field, Schema as ArrowSchema, SchemaRef};
 use datafusion::arrow::datatypes::{Fields, SchemaBuilder};
+use datafusion::catalog::TableProvider;
 use datafusion::catalog::{CatalogProvider, SchemaProvider};
-use datafusion::catalog::{MemoryCatalogProvider, TableProvider};
 use datafusion::datasource::DefaultTableSource;
 use datafusion::datasource::default_table_source::provider_as_source;
 use datafusion::datasource::file_format::FileFormat;
@@ -72,7 +68,6 @@ use datafusion_expr::{
     build_join_schema, is_null, lit, when,
 };
 use datafusion_iceberg::DataFusionTable;
-use datafusion_iceberg::catalog::catalog::IcebergCatalog;
 use datafusion_iceberg::table::DataFusionTableConfigBuilder;
 use datafusion_physical_plan::collect;
 use functions::semi_structured::variant::visitors::visit_all;
@@ -83,7 +78,6 @@ use functions::visitors::{
     table_functions_cte_relation, timestamp, top_limit,
     unimplemented::functions_checker::visit as unimplemented_functions_checker,
 };
-use iceberg_rust::catalog::Catalog;
 use iceberg_rust::catalog::create::CreateTableBuilder;
 use iceberg_rust::catalog::tabular::Tabular;
 use iceberg_rust::error::Error as IcebergError;
@@ -123,11 +117,6 @@ pub struct UserQuery {
     pub query: String,
     pub session: Arc<UserSession>,
     pub query_context: QueryContext,
-}
-
-pub enum IcebergCatalogResult {
-    Catalog(Arc<dyn Catalog>),
-    Result(Result<QueryResult>),
 }
 
 impl UserQuery {
@@ -177,29 +166,6 @@ impl UserQuery {
             .clone()
             .or_else(|| self.session.get_session_variable("schema"))
             .unwrap_or_else(|| "public".to_string())
-    }
-
-    #[instrument(
-        name = "UserQuery::refresh_catalog_partially",
-        level = "debug",
-        skip(self),
-        err
-    )]
-    async fn refresh_catalog_partially(&self, entity: CachedEntity) -> Result<()> {
-        if let Some(catalog_list_impl) = self
-            .session
-            .ctx
-            .state()
-            .catalog_list()
-            .as_any()
-            .downcast_ref::<EmbucketCatalogList>()
-        {
-            catalog_list_impl
-                .invalidate_cache(entity.normalized())
-                .await
-                .context(RefreshCatalogListSnafu)?;
-        }
-        Ok(())
     }
 
     #[instrument(name = "UserQuery::drop_catalog", level = "debug", skip(self), err)]
@@ -296,8 +262,7 @@ impl UserQuery {
         skip(self),
         fields(
             statement,
-            query_id = self.query_context.query_id.as_i64(),
-            query_uuid = self.query_context.query_id.as_uuid().to_string(),
+            query_id = self.query_context.query_id.to_string(),
         ),
         err
     )]
@@ -466,58 +431,6 @@ impl UserQuery {
                 }
                 .build()
             })
-    }
-
-    /// The code below relies on [`Catalog`] trait for different iceberg catalog
-    /// implementations (REST, S3 table buckets, or anything else).
-    /// In case this is built-in datafusion's [`MemoryCatalogProvider`] we shortcut and rely on its implementation
-    /// to actually execute logical plan.
-    /// Otherwise, code tries to downcast catalog to [`Catalog`] and if successful,
-    /// return the catalog
-    #[instrument(
-        name = "UserQuery::resolve_iceberg_catalog_or_execute",
-        level = "trace",
-        skip(self, catalog)
-    )]
-    pub async fn resolve_iceberg_catalog_or_execute(
-        &self,
-        catalog: Arc<dyn CatalogProvider>,
-        catalog_name: String,
-        plan: LogicalPlan,
-    ) -> IcebergCatalogResult {
-        // Try to downcast to CachingCatalog first since all catalogs are registered as CachingCatalog
-        let catalog =
-            if let Some(caching_catalog) = catalog.as_any().downcast_ref::<CachingCatalog>() {
-                &caching_catalog.catalog
-            } else {
-                return IcebergCatalogResult::Result(
-                    ex_error::CatalogDownCastSnafu {
-                        catalog: catalog_name,
-                    }
-                    .fail(),
-                );
-            };
-
-        // Try to resolve the actual underlying catalog type
-        if let Some(iceberg_catalog) = catalog.as_any().downcast_ref::<IcebergCatalog>() {
-            IcebergCatalogResult::Catalog(iceberg_catalog.catalog())
-        } else if let Some(embucket_catalog) = catalog.as_any().downcast_ref::<EmbucketCatalog>() {
-            IcebergCatalogResult::Catalog(embucket_catalog.catalog())
-        } else if catalog
-            .as_any()
-            .downcast_ref::<MemoryCatalogProvider>()
-            .is_some()
-        {
-            let result = self.execute_logical_plan(plan).await;
-            IcebergCatalogResult::Result(result)
-        } else {
-            IcebergCatalogResult::Result(
-                ex_error::CatalogDownCastSnafu {
-                    catalog: catalog_name,
-                }
-                .fail(),
-            )
-        }
     }
 
     #[instrument(name = "UserQuery::set_variable", level = "trace", skip(self), err)]
@@ -826,10 +739,10 @@ impl UserQuery {
             .execute_and_check(plan, self.session.ctx.state().config_options(), |_, _| ())
             .context(ex_error::DataFusionSnafu)?;
 
-        let ident: MetastoreTableIdent = new_table_ident.into();
-        let catalog_name = ident.database.clone();
-
-        // Inject more information to to the error
+        // Inject more information to the error
+        let table_ref = self.resolve_ident(&new_table_ident)?;
+        let catalog_name = table_ref.catalog.to_string();
+        let table_name = table_ref.table.to_string();
         let catalog = self.get_catalog(&catalog_name).map_err(|_| {
             ex_error::CatalogNotFoundSnafu {
                 operation_on: OperationOn::Table(OperationType::Create),
@@ -837,19 +750,27 @@ impl UserQuery {
             }
             .build()
         })?;
-        self.create_iceberg_table(
-            catalog.clone(),
-            catalog_name.clone(),
+        let schema_provider = catalog.schema(&table_ref.schema).ok_or_else(|| {
+            ex_error::SchemaNotFoundInDatabaseSnafu {
+                operation_on: OperationOn::Table(OperationType::Drop),
+                schema: table_ref.schema.to_string(),
+                db: catalog_name.clone(),
+            }
+            .build()
+        })?;
+
+        let table_provider: Option<Arc<dyn TableProvider>> = self.create_iceberg_table_provider(
+            table_ref,
+            schema_provider.clone(),
             table_location,
-            ident.clone(),
             create_table_statement,
             plan.clone(),
-        )
-        .await?;
-
-        // Now we have created table in the metastore, we need to register it in the catalog
-        self.refresh_catalog_partially(CachedEntity::Table(ident))
-            .await?;
+        )?;
+        if let Some(provider) = table_provider {
+            schema_provider
+                .register_table(table_name, provider)
+                .context(ex_error::DataFusionSnafu)?;
+        }
 
         // Insert data to new table
         // Since we don't execute logical plan, and we don't transform it to physical plan and
@@ -900,57 +821,30 @@ impl UserQuery {
         self.created_entity_response()
     }
 
-    #[allow(unused_variables)]
+    #[allow(unused_variables, clippy::needless_pass_by_value)]
     #[instrument(
         name = "UserQuery::create_iceberg_table",
         level = "trace",
         skip(self),
         err
     )]
-    pub async fn create_iceberg_table(
+    pub fn create_iceberg_table_provider(
         &self,
-        catalog: Arc<dyn CatalogProvider>,
-        catalog_name: String,
+        table_ref: ResolvedTableReference,
+        schema_provider: Arc<dyn SchemaProvider>,
         table_location: Option<String>,
-        ident: MetastoreTableIdent,
         statement: CreateTableStatement,
         plan: LogicalPlan,
-    ) -> Result<QueryResult> {
-        let iceberg_catalog = match self
-            .resolve_iceberg_catalog_or_execute(catalog, catalog_name, plan.clone())
-            .await
-        {
-            IcebergCatalogResult::Catalog(catalog) => catalog,
-            IcebergCatalogResult::Result(result) => {
-                return result.map(|_| self.created_entity_response())?;
-            }
-        };
-
-        let iceberg_ident = ident.to_iceberg_ident();
-
-        // Check if it already exists, if exists and CREATE OR REPLACE - drop it
-        let table_exists = iceberg_catalog
-            .clone()
-            .load_tabular(&iceberg_ident)
-            .await
-            .is_ok();
-
-        if table_exists {
+    ) -> Result<Option<Arc<dyn TableProvider>>> {
+        // Check if table already exists, if exists and CREATE OR REPLACE - drop it
+        if schema_provider.table_exist(&table_ref.table) {
             if statement.if_not_exists {
-                return self.created_entity_response();
+                return Ok(None);
             }
-
             if statement.or_replace {
-                iceberg_catalog
-                    .drop_table(&iceberg_ident)
-                    .await
-                    .context(ex_error::IcebergSnafu)?;
-            } else {
-                return ex_error::ObjectAlreadyExistsSnafu {
-                    r#type: ExistingObjectType::Table,
-                    name: ident.to_string(),
-                }
-                .fail();
+                schema_provider
+                    .deregister_table(&table_ref.table)
+                    .context(ex_error::DataFusionSnafu)?;
             }
         }
 
@@ -990,15 +884,11 @@ impl UserQuery {
             .map_err(|err| DataFusionError::External(Box::new(err)))
             .context(ex_error::DataFusionSnafu)?;
 
-        let mut create_table = CreateTableBuilder::default();
-        create_table
-            .with_name(ident.table)
-            .with_schema(schema)
-            // .with_location(location.clone())
-            .build(&[ident.schema], iceberg_catalog)
-            .await
-            .context(ex_error::IcebergSnafu)?;
-        self.created_entity_response()
+        let mut builder = CreateTableBuilder::default();
+        builder
+            .with_name(table_ref.table.to_string())
+            .with_schema(schema);
+        Ok(Some(Arc::new(IcebergTableBuilder::new(builder))))
     }
 
     #[instrument(
@@ -1916,14 +1806,7 @@ impl UserQuery {
             ),
             QueryContext::default(),
         );
-        let res = query.execute().await;
-
-        let table_ident: MetastoreTableIdent = object_name.into();
-
-        self.refresh_catalog_partially(CachedEntity::Table(table_ident))
-            .await?;
-
-        res
+        query.execute().await
     }
 
     pub fn resolve_show_in_name(
@@ -2557,6 +2440,26 @@ impl UserQuery {
             },
             _ => references.first().cloned(),
         }
+    }
+
+    fn resolve_ident(&self, table_ident: &NormalizedIdent) -> Result<ResolvedTableReference> {
+        let ident = table_ident.0.clone();
+        let table_ref = match ident.len() {
+            1 => TableReference::bare(ident[0].value.clone()),
+            2 => TableReference::partial(ident[0].value.clone(), ident[1].value.clone()),
+            3 => TableReference::full(
+                ident[0].value.clone(),
+                ident[1].value.clone(),
+                ident[2].value.clone(),
+            ),
+            _ => {
+                return ex_error::InvalidTableIdentifierSnafu {
+                    ident: table_ident.to_string(),
+                }
+                .fail();
+            }
+        };
+        Ok(self.resolve_table_ref(table_ref))
     }
 
     // Fill in the database and schema if they are missing

--- a/crates/executor/src/query_types.rs
+++ b/crates/executor/src/query_types.rs
@@ -1,71 +1,8 @@
 use serde::{Deserialize, Serialize};
-use std::fmt::{Debug, Display};
-use std::str::FromStr;
+use std::fmt::Debug;
 use uuid::Uuid;
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
-pub struct QueryRecordId(pub i64);
-
-impl QueryRecordId {
-    #[must_use]
-    pub const fn as_i64(self) -> i64 {
-        self.0
-    }
-
-    #[must_use]
-    pub fn as_uuid(self) -> Uuid {
-        let mut bytes = [0u8; 16];
-        bytes[8..].copy_from_slice(&self.0.to_be_bytes());
-        Uuid::from_bytes(bytes)
-    }
-}
-
-impl Debug for QueryRecordId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl Display for QueryRecordId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<i64> for QueryRecordId {
-    fn from(value: i64) -> Self {
-        Self(value)
-    }
-}
-
-impl From<QueryRecordId> for i64 {
-    fn from(value: QueryRecordId) -> Self {
-        value.0
-    }
-}
-
-impl FromStr for QueryRecordId {
-    type Err = std::num::ParseIntError;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(s.parse()?))
-    }
-}
-
-impl From<Uuid> for QueryRecordId {
-    fn from(value: Uuid) -> Self {
-        let bytes = value.as_bytes();
-        // Safety: UUID is 16 bytes, we take the last 8 bytes [8..16]
-        Self(i64::from_be_bytes([
-            bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15],
-        ]))
-    }
-}
-
-impl From<QueryRecordId> for Uuid {
-    fn from(value: QueryRecordId) -> Self {
-        value.as_uuid()
-    }
-}
+pub type QueryId = Uuid;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum QueryStatus {

--- a/crates/executor/src/running_queries.rs
+++ b/crates/executor/src/running_queries.rs
@@ -1,45 +1,69 @@
 use super::error::{self as ex_error, Result};
-use crate::query_types::{QueryRecordId, QueryStatus};
+use super::models::QueryResult;
+use crate::query_types::{QueryId, QueryStatus};
 use dashmap::DashMap;
-use snafu::OptionExt;
+use snafu::{OptionExt, ResultExt};
 use std::sync::Arc;
 use tokio::sync::watch;
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
-#[derive(Debug, Clone)]
+// RunningQuery can't be cloned and most of the time lives in RunningQueriesRegistry,
+// it can't be used directly and only accessible by reference from RunningQueriesRegistry
+#[derive(Debug)]
 pub struct RunningQuery {
-    pub query_id: QueryRecordId,
+    pub query_id: QueryId,
     pub request_id: Option<Uuid>,
-    cancellation_token: CancellationToken,
+    // save result handle here, so when query finishes caller will retrieve handle
+    // by removing RunningQuery from registry and will get result using result handle
+    pub result_handle: Option<JoinHandle<Result<QueryResult>>>,
+    pub cancellation_token: CancellationToken,
     // user can be notified when query is finished
     tx: watch::Sender<QueryStatus>,
     rx: watch::Receiver<QueryStatus>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum RunningQueryId {
-    ByQueryId(QueryRecordId),  // (query_id)
+    ByQueryId(QueryId),        // (query_id)
     ByRequestId(Uuid, String), // (request_id, sql_text)
 }
 
 impl RunningQuery {
     #[must_use]
-    pub fn new(query_id: QueryRecordId) -> Self {
+    pub fn new(query_id: QueryId) -> Self {
         let (tx, rx) = watch::channel(QueryStatus::Running);
         Self {
             query_id,
             request_id: None,
             cancellation_token: CancellationToken::new(),
+            result_handle: None,
             tx,
             rx,
         }
     }
     #[must_use]
-    pub const fn with_request_id(mut self, request_id: Uuid) -> Self {
-        self.request_id = Some(request_id);
-        self
+    pub fn with_request_id(self, request_id: Option<Uuid>) -> Self {
+        Self { request_id, ..self }
     }
+
+    #[must_use]
+    pub fn with_result_handle(self, result_handle: JoinHandle<Result<QueryResult>>) -> Self {
+        Self {
+            result_handle: Some(result_handle),
+            ..self
+        }
+    }
+
+    #[must_use]
+    pub fn with_cancellation_token(self, cancellation_token: CancellationToken) -> Self {
+        Self {
+            cancellation_token,
+            ..self
+        }
+    }
+
     pub fn cancel(&self) {
         self.cancellation_token.cancel();
     }
@@ -58,19 +82,20 @@ impl RunningQuery {
     }
 
     #[tracing::instrument(
-        name = "RunningQuery::recv_query_finished",
+        name = "RunningQuery::wait_query_finished",
         level = "trace",
         skip(self),
         err
     )]
-    pub async fn recv_query_finished(
-        &mut self,
+    pub async fn wait_query_finished(
+        &self,
     ) -> std::result::Result<QueryStatus, watch::error::RecvError> {
         // use loop here to bypass default query status we posted at init
         // it should not go to the actual loop and should resolve as soon as results are ready
+        let mut rx = self.rx.clone();
         loop {
-            self.rx.changed().await?;
-            let status = *self.rx.borrow();
+            rx.changed().await?;
+            let status = *rx.borrow();
             if status != QueryStatus::Running {
                 break Ok(status);
             }
@@ -80,9 +105,9 @@ impl RunningQuery {
 
 pub struct RunningQueriesRegistry {
     // <query_id, RunningQuery>
-    queries: Arc<DashMap<i64, RunningQuery>>,
-    // <request_id, QueryRecordId> To associate request_id with query_id
-    requests_ids: Arc<DashMap<Uuid, QueryRecordId>>,
+    queries: Arc<DashMap<QueryId, RunningQuery>>,
+    // <request_id, QueryId> To associate request_id with query_id
+    requests_ids: Arc<DashMap<Uuid, QueryId>>,
 }
 
 impl Default for RunningQueriesRegistry {
@@ -99,70 +124,55 @@ impl RunningQueriesRegistry {
             requests_ids: Arc::new(DashMap::new()),
         }
     }
+
+    #[tracing::instrument(
+        name = "RunningQueriesRegistry::wait_query_finished",
+        level = "trace",
+        skip(self),
+        err
+    )]
+    pub async fn wait_query_finished(&self, query_id: QueryId) -> Result<QueryStatus> {
+        let running_query = self
+            .queries
+            .get(&query_id)
+            .context(ex_error::QueryIsntRunningSnafu { query_id })?;
+        running_query
+            .wait_query_finished()
+            .await
+            .context(ex_error::QueryStatusRecvSnafu { query_id })
+    }
 }
 
 // RunningQueries interface allows cancel queries by query_id or request_id
+#[async_trait::async_trait]
 pub trait RunningQueries: Send + Sync {
-    fn add(&self, running_query: RunningQuery) -> CancellationToken;
-    fn remove(&self, running_query_id: RunningQueryId) -> Result<RunningQuery>;
-    fn abort(&self, abort_query: RunningQueryId) -> Result<()>;
-    fn is_running(&self, running_query_id: RunningQueryId) -> bool;
+    fn add(&self, running_query: RunningQuery);
+    fn remove(&self, query_id: QueryId) -> Result<RunningQuery>;
+    fn abort(&self, query_id: QueryId) -> Result<()>;
+    fn notify_query_finished(&self, query_id: QueryId, status: QueryStatus) -> Result<()>;
+    fn locate_query_id(&self, running_query_id: RunningQueryId) -> Result<QueryId>;
     fn count(&self) -> usize;
-    fn get(&self, running_query_id: RunningQueryId) -> Result<RunningQuery>;
 }
 
 impl RunningQueries for RunningQueriesRegistry {
     #[tracing::instrument(name = "RunningQueriesRegistry::add", level = "trace", skip(self))]
-    fn add(&self, running_query: RunningQuery) -> CancellationToken {
-        let cancellation_token = running_query.cancellation_token.clone();
-
+    fn add(&self, running_query: RunningQuery) {
         // map query_id to request_id
         if let Some(request_id) = running_query.request_id {
             self.requests_ids.insert(request_id, running_query.query_id);
         }
 
         // map RunningQuery to query_id
-        self.queries
-            .insert(running_query.query_id.as_i64(), running_query);
-
-        cancellation_token
+        self.queries.insert(running_query.query_id, running_query);
     }
 
-    #[tracing::instrument(
-        name = "RunningQueriesRegistry::remove",
-        level = "trace",
-        skip(self),
-        err
-    )]
-    fn remove(&self, running_query_id: RunningQueryId) -> Result<RunningQuery> {
-        let query_id = self.get(running_query_id)?.query_id;
-        if let Some((_query_id, running_query)) = self.queries.remove(&query_id.as_i64()) {
-            Ok(running_query)
-        } else {
-            ex_error::QueryIsntRunningSnafu { query_id }.fail()
-        }
-    }
-
-    fn get(&self, running_query_id: RunningQueryId) -> Result<RunningQuery> {
-        let running_query = match running_query_id {
-            RunningQueryId::ByQueryId(query_id) => self
-                .queries
-                .get(&query_id.as_i64())
-                .context(ex_error::QueryIsntRunningSnafu { query_id })?,
-            RunningQueryId::ByRequestId(request_id, _sql_text) => {
-                let query_id = self
-                    .requests_ids
-                    .get(&request_id)
-                    .context(ex_error::QueryByRequestIdIsntRunningSnafu { request_id })?;
-                self.queries
-                    .get(&query_id.as_i64())
-                    .context(ex_error::QueryIsntRunningSnafu {
-                        query_id: query_id.as_i64(),
-                    })?
-            }
-        };
-        // Can't return reference to RunningQuery, but it quite small so clone it
-        Ok(running_query.clone())
+    #[tracing::instrument(name = "RunningQueriesRegistry::remove", level = "trace", skip(self))]
+    fn remove(&self, query_id: QueryId) -> Result<RunningQuery> {
+        let (_, running_query) = self
+            .queries
+            .remove(&query_id)
+            .context(ex_error::QueryIsntRunningSnafu { query_id })?;
+        Ok(running_query)
     }
 
     #[tracing::instrument(
@@ -172,38 +182,44 @@ impl RunningQueries for RunningQueriesRegistry {
         fields(running_queries_count = self.count()),
         err
     )]
-    fn abort(&self, abort_query: RunningQueryId) -> Result<()> {
-        // Two phase mechanism:
-        // 1 - cancel query using cancellation_token
-        // 2 - ExecutionService removes RunningQuery from RunningQueriesRegistry
-        match abort_query {
-            RunningQueryId::ByQueryId(query_id) => {
-                let running_query = self
-                    .queries
-                    .get(&query_id.as_i64())
-                    .context(ex_error::QueryIsntRunningSnafu { query_id })?;
-                running_query.cancel();
-            }
-            // sql_text is not realy used for aborting query. Should it be checked too?
-            RunningQueryId::ByRequestId(request_id, _sql_text) => {
-                let query_record_id = self
-                    .requests_ids
-                    .get(&request_id)
-                    .context(ex_error::QueryByRequestIdIsntRunningSnafu { request_id })?;
-                self.abort(RunningQueryId::ByQueryId(*query_record_id))?;
-            }
-        }
+    fn abort(&self, query_id: QueryId) -> Result<()> {
+        let running_query = self
+            .queries
+            .get(&query_id)
+            .context(ex_error::QueryIsntRunningSnafu { query_id })?;
+        running_query.cancel();
         Ok(())
     }
 
     #[tracing::instrument(
-        name = "RunningQueriesRegistry::exists",
+        name = "RunningQueriesRegistry::notify_query_finished",
+        level = "trace",
+        skip(self),
+        err
+    )]
+    fn notify_query_finished(&self, query_id: QueryId, status: QueryStatus) -> Result<()> {
+        let running_query = self
+            .queries
+            .get(&query_id)
+            .context(ex_error::QueryIsntRunningSnafu { query_id })?;
+        let _ = running_query.notify_query_finished(status);
+        Ok(())
+    }
+
+    #[tracing::instrument(
+        name = "RunningQueriesRegistry::locate_query_id",
         level = "trace",
         skip(self),
         ret
     )]
-    fn is_running(&self, running_query_id: RunningQueryId) -> bool {
-        self.get(running_query_id).is_ok()
+    fn locate_query_id(&self, running_query_id: RunningQueryId) -> Result<QueryId> {
+        match running_query_id {
+            RunningQueryId::ByRequestId(request_id, _sql_text) => Ok(*self
+                .requests_ids
+                .get(&request_id)
+                .context(ex_error::QueryByRequestIdIsntRunningSnafu { request_id })?),
+            RunningQueryId::ByQueryId(query_id) => Ok(query_id),
+        }
     }
 
     fn count(&self) -> usize {

--- a/crates/executor/src/service.rs
+++ b/crates/executor/src/service.rs
@@ -15,16 +15,18 @@ use datafusion::execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
 use datafusion_common::TableReference;
 use snafu::ResultExt;
 use std::num::NonZeroUsize;
-use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::atomic::Ordering;
 use std::vec;
 use std::{collections::HashMap, sync::Arc};
 use time::{Duration as DateTimeDuration, OffsetDateTime};
+use tokio::task;
+use tokio_util::sync::CancellationToken;
 
 use super::error::{self as ex_error, Result};
-use super::models::{AsyncQueryHandle, QueryContext, QueryResult, QueryResultStatus};
+use super::models::{QueryContext, QueryResult};
 use super::running_queries::{RunningQueries, RunningQueriesRegistry, RunningQuery};
 use super::session::UserSession;
-use crate::query_types::{QueryRecordId, QueryStatus};
+use crate::query_types::{QueryId, QueryStatus};
 use crate::running_queries::RunningQueryId;
 use crate::session::{SESSION_INACTIVITY_EXPIRATION_SECONDS, to_unix};
 use crate::tracing::SpanTracer;
@@ -35,8 +37,7 @@ use catalog_metastore::{
     Volume, VolumeType,
 };
 use tokio::sync::RwLock;
-use tokio::sync::oneshot;
-use tokio::time::{Duration, timeout};
+use tokio::time::Duration;
 use tracing::Instrument;
 use uuid::Uuid;
 
@@ -54,20 +55,32 @@ pub trait ExecutionService: Send + Sync {
     async fn delete_session(&self, session_id: &str) -> Result<()>;
     fn get_sessions(&self) -> Arc<RwLock<HashMap<String, Arc<UserSession>>>>;
 
-    /// Aborts a query by `query_id` or `request_id`.
+    /// Locates a query by `running_query_id`.
     ///
     /// # Arguments
     ///
-    /// * `abort_query` - The query to abort. Provided either `query_id` or `request_id` and `sql_text`.
+    /// * `running_query_id` - The running query id.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` of type `QueryId`. The `Ok` variant contains the query id,
+    /// and the `Err` variant contains an `Error`.
+    fn locate_query_id(&self, running_query_id: RunningQueryId) -> Result<QueryId>;
+
+    /// Aborts a query by `query_id`.
+    ///
+    /// # Arguments
+    ///
+    /// * `query_id` - The query to abort.
     ///
     /// # Returns
     ///
     /// A `Result` of type `()`. The `Ok` variant contains an empty tuple,
     /// and the `Err` variant contains an `Error`.
-    fn abort_query(&self, abort_query: RunningQueryId) -> Result<()>;
+    fn abort(&self, query_id: QueryId) -> Result<()>;
 
     /// Submits a query to be executed asynchronously. Query result can be consumed with
-    /// `wait_submitted_query_result`.
+    /// `wait`.
     ///
     /// # Arguments
     ///
@@ -77,31 +90,28 @@ pub trait ExecutionService: Send + Sync {
     ///
     /// # Returns
     ///
-    /// A `Result` of type `AsyncQueryHandle`. The `Ok` variant contains the query handle,
-    /// to be used with `wait_submitted_query_result`. The `Err` variant contains submission `Error`.
-    async fn submit_query(
+    /// A `Result` of type `QueryId`. The `Ok` variant contains the query id,
+    /// to be used with `wait`. The `Err` variant contains submission `Error`.
+    async fn submit(
         &self,
         session_id: &str,
         query: &str,
         query_context: QueryContext,
-    ) -> Result<AsyncQueryHandle>;
+    ) -> Result<QueryId>;
 
     /// Wait while sabmitted query finished, it returns query result or real context rich error
     /// # Arguments
     ///
-    /// * `query_handle` - The handle of the submitted query.
+    /// * `query_id` - The id of the submitted query.
     ///
     /// # Returns
     ///
     /// A `Result` of type `QueryResult`. The `Ok` variant contains the query result,
     /// and the `Err` variant contains a real context rich error.
-    async fn wait_submitted_query_result(
-        &self,
-        query_handle: AsyncQueryHandle,
-    ) -> Result<QueryResult>;
+    async fn wait(&self, query_id: QueryId) -> Result<QueryResult>;
 
     /// Synchronously executes a query and returns the result.
-    /// It is a wrapper around `submit_query` and `wait_submitted_query_result`.
+    /// It is a wrapper around `submit` and `wait`.
     ///
     /// # Arguments
     ///
@@ -139,7 +149,6 @@ pub struct CoreExecutionService {
     catalog_list: Arc<EmbucketCatalogList>,
     runtime_env: Arc<RuntimeEnv>,
     queries: Arc<RunningQueriesRegistry>,
-    next_query_id: AtomicI64,
 }
 
 impl CoreExecutionService {
@@ -166,7 +175,6 @@ impl CoreExecutionService {
             catalog_list,
             runtime_env,
             queries: Arc::new(RunningQueriesRegistry::new()),
-            next_query_id: AtomicI64::new(1),
         })
     }
 
@@ -300,10 +308,6 @@ impl CoreExecutionService {
 
     fn initialize_datafusion_tracer() {
         let _ = set_join_set_tracer(&SpanTracer);
-    }
-
-    fn next_query_id(&self) -> QueryRecordId {
-        QueryRecordId(self.next_query_id.fetch_add(1, Ordering::Relaxed))
     }
 }
 
@@ -479,179 +483,168 @@ impl ExecutionService for CoreExecutionService {
         query: &str,
         query_context: QueryContext,
     ) -> Result<QueryResult> {
-        let query_handle = self.submit_query(session_id, query, query_context).await?;
-        self.wait_submitted_query_result(query_handle).await
+        let query_id = self.submit(session_id, query, query_context).await?;
+        self.wait(query_id).await
+    }
+
+    #[tracing::instrument(name = "ExecutionService::wait", level = "debug", skip(self), err)]
+    async fn wait(&self, query_id: QueryId) -> Result<QueryResult> {
+        let _query_status = self.queries.wait_query_finished(query_id).await?;
+        let running_query = self.queries.remove(query_id)?;
+        if let Some(result_handle) = running_query.result_handle {
+            result_handle
+                .await
+                .context(ex_error::AsyncResultTaskJoinSnafu { query_id })?
+        } else {
+            Err(ex_error::NoJoinHandleSnafu { query_id }.build())
+        }
     }
 
     #[tracing::instrument(
-        name = "ExecutionService::wait_submitted_query_result",
+        name = "ExecutionService::locate_query_id",
         level = "debug",
-        skip(self, query_handle),
-        fields(query_id = query_handle.query_id.as_i64(), query_uuid = query_handle.query_id.as_uuid().to_string()),
-        err
+        skip(self)
     )]
-    async fn wait_submitted_query_result(
-        &self,
-        query_handle: AsyncQueryHandle,
-    ) -> Result<QueryResult> {
-        let query_id = query_handle.query_id;
-        if !self.queries.is_running(RunningQueryId::ByQueryId(query_id)) {
-            return ex_error::QueryIsntRunningSnafu { query_id }.fail();
-        }
-
-        let recv_result = query_handle.rx.await;
-        // do some handling on result recv error
-        if recv_result.is_err() {
-            // just in case, log error in this way
-            tracing::error_span!(
-                "error_receiving_query_result_status",
-                query_id = query_id.as_i64(),
-                query_uuid = query_id.as_uuid().to_string(),
-            );
-        }
-
-        let query_result_status =
-            recv_result.context(ex_error::QueryResultRecvSnafu { query_id })?;
-
-        Ok(query_result_status.query_result?)
+    fn locate_query_id(&self, running_query_id: RunningQueryId) -> Result<QueryId> {
+        self.queries.locate_query_id(running_query_id)
     }
 
     #[tracing::instrument(
-        name = "ExecutionService::abort_query",
+        name = "ExecutionService::abort",
         level = "debug",
         skip(self),
         fields(old_queries_count = self.queries.count()),
         err
     )]
-    fn abort_query(&self, abort_query: RunningQueryId) -> Result<()> {
-        self.queries.abort(abort_query)
+    fn abort(&self, query_id: QueryId) -> Result<()> {
+        self.queries.abort(query_id)
     }
 
     #[tracing::instrument(
-        name = "ExecutionService::submit_query",
+        name = "ExecutionService::submit",
         level = "debug",
         skip(self),
-        fields(query_id, query_uuid, old_queries_count = self.queries.count()),
+        fields(query_id, with_timeout_secs, old_queries_count = self.queries.count()),
         err
     )]
-    async fn submit_query(
+    async fn submit(
         &self,
         session_id: &str,
         query: &str,
         query_context: QueryContext,
-    ) -> Result<AsyncQueryHandle> {
+    ) -> Result<QueryId> {
         let user_session = self.get_session(session_id).await?;
 
         if self.queries.count() >= self.config.max_concurrency_level {
             return ex_error::ConcurrencyLimitSnafu.fail();
         }
 
-        let query_id = self.next_query_id();
+        let query_id = Uuid::new_v4();
 
         // Record the result as part of the current span.
         tracing::Span::current()
-            .record("query_id", query_id.as_i64())
-            .record("query_uuid", query_id.as_uuid().to_string());
+            .record("query_id", query_id.to_string())
+            .record("with_timeout_secs", self.config.query_timeout_secs);
 
-        // Create RunningQuery before query execution as query_context is then transfered to the query object
-        let running_query = if let Some(request_id) = &query_context.request_id {
-            RunningQuery::new(query_id).with_request_id(*request_id)
-        } else {
-            RunningQuery::new(query_id)
-        };
-
-        // Attach the generated query ID to the query context before execution.
-        let query_obj = user_session.query(query, query_context.with_query_id(query_id));
-
-        let cancel_token = self.queries.add(running_query);
-
+        let request_id = query_context.request_id;
+        let query = query.to_string();
         let query_timeout_secs = self.config.query_timeout_secs;
-        let queries_ref = self.queries.clone();
+        let queries_clone = self.queries.clone();
+        let query_token = CancellationToken::new();
+        let query_token_clone = query_token.clone();
 
-        let (tx, rx) = oneshot::channel();
-
-        let child = tracing::info_span!("spawn_query_task");
+        let task_span = tracing::info_span!("spawn_query_task");
 
         let alloc_span = tracing::info_span!(
             target: "alloc",
             "query_alloc",
-            query_id = %query_id.as_i64(),
+            query_id = %query_id,
             session_id = %session_id
         );
-        tokio::spawn(async move {
-            let mut query_obj = query_obj;
-            // Execute the query with a timeout to prevent long-running or stuck queries
-            // from blocking system resources indefinitely. If the timeout is exceeded,
-            // convert the timeout into a standard QueryTimeout error so it can be handled
-            // and recorded like any other execution failure.
-            let result_fut = timeout(Duration::from_secs(query_timeout_secs), query_obj.execute());
+        let handle = tokio::spawn(async move {
+            let sub_task_span = tracing::info_span!("spawn_query_sub_task");
+            let mut query_obj = user_session.query(query, query_context.with_query_id(query_id));
+
+            // Create nested task so in case of abort/timeout it can be aborted
+            // and result is handled properly (status / query result saved)
+            let subtask_fut = task::spawn(async move {
+                query_obj.execute().instrument(sub_task_span).await
+            });
+            let subtask_abort_handle = subtask_fut.abort_handle();
 
             // wait for any future to be resolved
-            let query_result_status = tokio::select! {
-                finished = result_fut => {
+            let (query_result, query_status) = tokio::select! {
+                finished = subtask_fut => {
                     match finished {
                         Ok(inner_result) => {
                             // set query execution status to successful or failed
                             let status = inner_result.as_ref().map_or_else(|_| QueryStatus::Failed, |_| QueryStatus::Successful);
-                            QueryResultStatus {
-                                query_result: inner_result.context(ex_error::QueryExecutionSnafu {
-                                    query_id,
-                                }),
-                                status,
-                            }
+                            (inner_result.context(ex_error::QueryExecutionSnafu {
+                                query_id,
+                            }), status)
                         },
-                        Err(_) => {
-                            QueryResultStatus {
-                                query_result: ex_error::QueryTimeoutSnafu.fail().context(ex_error::QueryExecutionSnafu {
-                                    query_id,
-                                }),
-                                status: QueryStatus::TimedOut,
-                            }
+                        Err(error) => {
+                            tracing::error!("Query {query_id} sub task join error: {error:?}");
+                            (Err(ex_error::Error::QuerySubtaskJoin { error, location: snafu::location!() }).context(ex_error::QueryExecutionSnafu {
+                                query_id,
+                            }), QueryStatus::Failed)
                         },
                     }
                 },
-                () = cancel_token.cancelled() => {
-                    QueryResultStatus {
-                        query_result: ex_error::QueryCancelledSnafu { query_id }.fail().context(ex_error::QueryExecutionSnafu {
-                            query_id,
-                        }),
-                        status: QueryStatus::Cancelled,
-                    }
+                () = query_token.cancelled() => {
+                    tracing::info_span!("query_cancelled_do_abort");
+                    subtask_abort_handle.abort();
+                    (ex_error::QueryCancelledSnafu { query_id }.fail().context(ex_error::QueryExecutionSnafu {
+                        query_id,
+                    }), QueryStatus::Cancelled)
+                },
+                // Execute the query with a timeout to prevent long-running or stuck queries
+                // from blocking system resources indefinitely. If the timeout is exceeded,
+                // convert the timeout into a standard QueryTimeout error so it can be handled
+                // and recorded like any other execution failure
+                () = tokio::time::sleep(Duration::from_secs(query_timeout_secs)) => {
+                    tracing::info_span!("query_timeout_received_do_abort");
+                    subtask_abort_handle.abort();
+                    (ex_error::QueryTimeoutSnafu.fail().context(ex_error::QueryExecutionSnafu {
+                        query_id,
+                    }), QueryStatus::TimedOut)
                 }
             };
 
-            let _ = tracing::debug_span!("spawned_query_task_result",
-                query_id = query_id.as_i64(),
-                query_uuid = query_id.as_uuid().to_string(),
-                query_status = format!("{:?}", query_result_status.status),
+            let _ = tracing::info_span!("finished_query_status",
+                query_id = query_id.to_string(),
+                query_status = format!("{query_status:?}"),
             )
             .entered();
 
-            // remove query from running queries registry
-            let running_query = queries_ref.remove(RunningQueryId::ByQueryId(query_id));
+            user_session.record_query_id(query_id);
 
-            let query_status = query_result_status.status;
+            // Notify subscribers query finishes and result is ready. 
+            // Do not immediately remove query from running queries registry
+            // as RunningQuery contains result handle that caller should consume.
+            queries_clone.notify_query_finished(query_id, query_status)?;
 
-            query_obj.session.record_query_id(query_id);
+            // Discard results after short timeout, to prevent memory leaks
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                let running_query = queries_clone.remove(query_id);
+                if let Ok(RunningQuery {result_handle: Some(result_handle), ..}) = running_query {
+                    tracing::debug!("Discarding '{query_status:?}' result for query {query_id}");
+                    let _ = result_handle.await;
+                }
+            });
 
-            // Send result to the result owner
-            if tx.send(query_result_status).is_err() {
-                // Error happens if receiver is dropped
-                // (natural in case if query submitted result owner doesn't listen)
-                tracing::error_span!("no_receiver_on_query_result_status",
-                    query_id = query_id.as_i64(),
-                    query_uuid = query_id.as_uuid().to_string(),
-                );
-            }
+            query_result
+        }.instrument(alloc_span).instrument(task_span));
 
-            // notify listeners that historical result is ready
-            if let Ok(running_query) = running_query {
-                let _ = running_query.notify_query_finished(query_status);
-            }
-        }.instrument(alloc_span).instrument(child));
+        self.queries.add(
+            RunningQuery::new(query_id)
+                .with_request_id(request_id)
+                .with_result_handle(handle)
+                .with_cancellation_token(query_token_clone),
+        );
 
-        // return handle of the query we just submit
-        Ok(AsyncQueryHandle { query_id, rx })
+        Ok(query_id)
     }
 
     #[tracing::instrument(

--- a/crates/executor/src/session.rs
+++ b/crates/executor/src/session.rs
@@ -11,7 +11,7 @@ use crate::datafusion::physical_optimizer::physical_optimizer_rules;
 use crate::datafusion::query_planner::CustomQueryPlanner;
 use crate::models::QueryContext;
 use crate::query::UserQuery;
-use crate::query_types::QueryRecordId;
+use crate::query_types::QueryId;
 use crate::running_queries::RunningQueries;
 use crate::utils::Config;
 use catalog::catalog_list::{DEFAULT_CATALOG, EmbucketCatalogList};
@@ -54,7 +54,7 @@ pub struct UserSession {
     pub config: Arc<Config>,
     pub expiry: AtomicI64,
     pub session_params: Arc<SessionParams>,
-    pub recent_queries: Arc<RwLock<VecDeque<QueryRecordId>>>,
+    pub recent_queries: Arc<RwLock<VecDeque<QueryId>>>,
 }
 
 impl UserSession {
@@ -213,7 +213,7 @@ impl UserSession {
         false
     }
 
-    pub fn record_query_id(&self, query_id: QueryRecordId) {
+    pub fn record_query_id(&self, query_id: QueryId) {
         const MAX_QUERIES: usize = 64;
         if let Ok(mut guard) = self.recent_queries.write() {
             guard.push_front(query_id);

--- a/crates/executor/src/tests/service.rs
+++ b/crates/executor/src/tests/service.rs
@@ -289,7 +289,7 @@ async fn test_max_concurrency_level() {
         let barrier = barrier.clone();
         tokio::spawn(async move {
             let _ = svc
-                .submit_query(
+                .submit(
                     "test_session_id",
                     "SELECT sleep(2)",
                     QueryContext::default(),
@@ -337,7 +337,7 @@ async fn test_max_concurrency_level2() {
 
     for _ in 0..2 {
         let _ = execution_svc
-            .submit_query(
+            .submit(
                 "test_session_id",
                 "SELECT sleep(2)",
                 QueryContext::default(),

--- a/crates/executor/src/tests/sql/ddl/snapshots/table/query_truncate_table_full.snap
+++ b/crates/executor/src/tests/sql/ddl/snapshots/table/query_truncate_table_full.snap
@@ -1,13 +1,14 @@
 ---
 source: crates/executor/src/tests/sql/ddl/table.rs
-description: "\"TRUNCATE TABLE embucket.public.employee_table\""
+description: "\"SELECT count() FROM embucket.public.employee_table\""
+info: "Setup queries: TRUNCATE TABLE embucket.public.employee_table"
 ---
 Ok(
     [
-        "+-------+",
-        "| count |",
-        "+-------+",
-        "| 0     |",
-        "+-------+",
+        "+---------+",
+        "| count() |",
+        "+---------+",
+        "| 0       |",
+        "+---------+",
     ],
 )

--- a/crates/executor/src/tests/sql/ddl/table.rs
+++ b/crates/executor/src/tests/sql/ddl/table.rs
@@ -258,7 +258,8 @@ test_query!(
 );
 test_query!(
     truncate_table_full,
-    "TRUNCATE TABLE embucket.public.employee_table",
+    "SELECT count() FROM embucket.public.employee_table",
+    setup_queries = ["TRUNCATE TABLE embucket.public.employee_table"],
     snapshot_path = "table"
 );
 test_query!(


### PR DESCRIPTION
Added TableProvider adapter that rewrites column names to match Snowflake's case-insensitive semantics.

Snowflake stores schemas in uppercase, while queries are typically written in lowercase. DataFusion treats identifiers as case-sensitive, which causes  mismatches between the logical projection expressions (lowercase) and the physical input schema (uppercase). This adapter:
- Rewrites column references in filter expressions to the original schema casing before delegating to the underlying table provider.
- Wraps the produced physical plan in a projection that aliases columns to lowercase names, so the output schema matches the logical expectations.