### PR TITLE
Add SHOW query context when preparing information schema

### DIFF
--- a/crates/catalog/src/catalog_list.rs
+++ b/crates/catalog/src/catalog_list.rs
@@ -240,7 +240,7 @@ impl EmbucketCatalogList {
             .context(catalog_error::DataFusionSnafu)?;
         Ok(
             CachingCatalog::new(Arc::new(catalog), name.to_string(), Some(iceberg_catalog))
-                .with_refresh(true)
+                .with_refresh(false)
                 .with_catalog_type(CatalogType::S3tables),
         )
     }

--- a/crates/catalog/src/information_schema/config.rs
+++ b/crates/catalog/src/information_schema/config.rs
@@ -17,8 +17,8 @@ use dashmap::DashMap;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::catalog::CatalogProviderList;
 use datafusion::logical_expr::{Signature, TypeSignature, Volatility};
-use datafusion_common::DataFusionError;
 use datafusion_common::config::ConfigOptions;
+use datafusion_common::{DataFusionError, TableReference};
 use datafusion_doc::Documentation;
 use datafusion_expr::{AggregateUDF, ScalarUDF, TableType, WindowUDF};
 use functions::session_params::SessionParams;
@@ -31,6 +31,7 @@ pub struct InformationSchemaConfig {
     pub(crate) catalog_list: Arc<dyn CatalogProviderList>,
     pub(crate) catalog_name: Arc<str>,
     pub(crate) views_schemas: DashMap<String, Arc<Schema>>,
+    pub(crate) show_statement_ref: Option<TableReference>,
 }
 
 impl InformationSchemaConfig {
@@ -43,11 +44,19 @@ impl InformationSchemaConfig {
             return Ok(());
         };
 
-        for schema_name in catalog
-            .schema_names()
-            .into_iter()
-            .filter(|s| s != INFORMATION_SCHEMA)
+        let schema_names: Vec<String> = if let Some(schema_ref) = self.show_statement_ref.clone()
+            && let Some(schema_name) = schema_ref.schema()
         {
+            vec![schema_name.to_string()]
+        } else {
+            catalog
+                .schema_names()
+                .into_iter()
+                .filter(|s| s != INFORMATION_SCHEMA)
+                .collect()
+        };
+
+        for schema_name in schema_names {
             let Some(schema) = catalog.schema(&schema_name) else {
                 continue;
             };
@@ -144,10 +153,20 @@ impl InformationSchemaConfig {
         builder: &mut InformationSchemaViewBuilder,
     ) -> datafusion_common::Result<(), DataFusionError> {
         if let Some(catalog) = self.catalog_list.catalog(&self.catalog_name) {
-            for schema_name in catalog.schema_names() {
-                if schema_name == INFORMATION_SCHEMA {
-                    continue;
-                }
+            let schema_names: Vec<String> = if let Some(schema_ref) =
+                self.show_statement_ref.clone()
+                && let Some(schema_name) = schema_ref.schema()
+            {
+                vec![schema_name.to_string()]
+            } else {
+                catalog
+                    .schema_names()
+                    .into_iter()
+                    .filter(|s| s != INFORMATION_SCHEMA)
+                    .collect()
+            };
+
+            for schema_name in schema_names {
                 if let Some(schema) = catalog.schema(&schema_name) {
                     for table_name in schema.table_names() {
                         if let Some(table) = schema.table(&table_name).await?
@@ -185,10 +204,20 @@ impl InformationSchemaConfig {
         builder: &mut InformationSchemaColumnsBuilder,
     ) -> datafusion_common::Result<(), DataFusionError> {
         if let Some(catalog) = self.catalog_list.catalog(&self.catalog_name) {
-            for schema_name in catalog.schema_names() {
-                if schema_name == INFORMATION_SCHEMA {
-                    continue;
-                }
+            let schema_names: Vec<String> = if let Some(schema_ref) =
+                self.show_statement_ref.clone()
+                && let Some(schema_name) = schema_ref.schema()
+            {
+                vec![schema_name.to_string()]
+            } else {
+                catalog
+                    .schema_names()
+                    .into_iter()
+                    .filter(|s| s != INFORMATION_SCHEMA)
+                    .collect()
+            };
+
+            for schema_name in schema_names {
                 if let Some(schema) = catalog.schema(&schema_name) {
                     for table_name in schema.table_names() {
                         if let Some(table) = schema.table(&table_name).await? {

--- a/crates/catalog/src/information_schema/config.rs
+++ b/crates/catalog/src/information_schema/config.rs
@@ -31,7 +31,7 @@ pub struct InformationSchemaConfig {
     pub(crate) catalog_list: Arc<dyn CatalogProviderList>,
     pub(crate) catalog_name: Arc<str>,
     pub(crate) views_schemas: DashMap<String, Arc<Schema>>,
-    pub(crate) show_statement_ref: Option<TableReference>,
+    pub(crate) target_reference: Option<TableReference>,
 }
 
 impl InformationSchemaConfig {
@@ -44,7 +44,7 @@ impl InformationSchemaConfig {
             return Ok(());
         };
 
-        let schema_names: Vec<String> = if let Some(schema_ref) = self.show_statement_ref.clone()
+        let schema_names: Vec<String> = if let Some(schema_ref) = self.target_reference.clone()
             && let Some(schema_name) = schema_ref.schema()
         {
             vec![schema_name.to_string()]
@@ -153,8 +153,7 @@ impl InformationSchemaConfig {
         builder: &mut InformationSchemaViewBuilder,
     ) -> datafusion_common::Result<(), DataFusionError> {
         if let Some(catalog) = self.catalog_list.catalog(&self.catalog_name) {
-            let schema_names: Vec<String> = if let Some(schema_ref) =
-                self.show_statement_ref.clone()
+            let schema_names: Vec<String> = if let Some(schema_ref) = self.target_reference.clone()
                 && let Some(schema_name) = schema_ref.schema()
             {
                 vec![schema_name.to_string()]
@@ -204,8 +203,7 @@ impl InformationSchemaConfig {
         builder: &mut InformationSchemaColumnsBuilder,
     ) -> datafusion_common::Result<(), DataFusionError> {
         if let Some(catalog) = self.catalog_list.catalog(&self.catalog_name) {
-            let schema_names: Vec<String> = if let Some(schema_ref) =
-                self.show_statement_ref.clone()
+            let schema_names: Vec<String> = if let Some(schema_ref) = self.target_reference.clone()
                 && let Some(schema_name) = schema_ref.schema()
             {
                 vec![schema_name.to_string()]

--- a/crates/catalog/src/information_schema/information_schema.rs
+++ b/crates/catalog/src/information_schema/information_schema.rs
@@ -16,8 +16,8 @@ use async_trait::async_trait;
 use dashmap::DashMap;
 use datafusion::catalog::streaming::StreamingTable;
 use datafusion::catalog::{CatalogProviderList, SchemaProvider, TableProvider};
-use datafusion_common::DataFusionError;
 use datafusion_common::Result;
+use datafusion_common::{DataFusionError, TableReference};
 use datafusion_physical_plan::streaming::PartitionStream;
 use std::fmt::Debug;
 use std::{any::Any, sync::Arc};
@@ -47,7 +47,11 @@ pub struct InformationSchemaProvider {
 
 impl InformationSchemaProvider {
     /// Creates a new [`InformationSchemaProvider`] for the provided `catalog_list`
-    pub fn new(catalog_list: Arc<dyn CatalogProviderList>, catalog_name: Arc<str>) -> Self {
+    pub fn new(
+        catalog_list: Arc<dyn CatalogProviderList>,
+        catalog_name: Arc<str>,
+        show_statement_ref: Option<TableReference>,
+    ) -> Self {
         let views_schemas = {
             let mut map = DashMap::new();
             map.extend(
@@ -72,6 +76,7 @@ impl InformationSchemaProvider {
                 catalog_list,
                 catalog_name,
                 views_schemas,
+                show_statement_ref,
             },
         }
     }

--- a/crates/catalog/src/information_schema/information_schema.rs
+++ b/crates/catalog/src/information_schema/information_schema.rs
@@ -50,7 +50,7 @@ impl InformationSchemaProvider {
     pub fn new(
         catalog_list: Arc<dyn CatalogProviderList>,
         catalog_name: Arc<str>,
-        show_statement_ref: Option<TableReference>,
+        target_reference: Option<TableReference>,
     ) -> Self {
         let views_schemas = {
             let mut map = DashMap::new();
@@ -76,7 +76,7 @@ impl InformationSchemaProvider {
                 catalog_list,
                 catalog_name,
                 views_schemas,
-                show_statement_ref,
+                target_reference,
             },
         }
     }

--- a/crates/catalog/src/tests/information_schema.rs
+++ b/crates/catalog/src/tests/information_schema.rs
@@ -30,6 +30,7 @@ async fn create_session_context() -> Arc<SessionContext> {
             Arc::new(InformationSchemaProvider::new(
                 catalog_list_impl.clone(),
                 Arc::from(DEFAULT_CATALOG),
+                None,
             )),
         )
         .unwrap();


### PR DESCRIPTION
- if the call to information schema contains specific schema, we don't need to build fetch data for all tables