### PR TITLE
Skip s3 tables catalog tree build

### DIFF
--- a/crates/catalog/src/catalog.rs
+++ b/crates/catalog/src/catalog.rs
@@ -177,7 +177,7 @@ impl CatalogProvider for CachingCatalog {
             }
             None => self.catalog.schema_names(),
         };
-        println!("schema_names {:?}", schema_names);
+
         // Remove outdated records
         let schema_names_set: std::collections::HashSet<_> = schema_names.iter().cloned().collect();
         self.schemas_cache

--- a/crates/catalog/src/catalog_list.rs
+++ b/crates/catalog/src/catalog_list.rs
@@ -243,9 +243,7 @@ impl EmbucketCatalogList {
             .context(catalog_error::S3TablesSnafu)?,
         );
 
-        let catalog = DataFusionIcebergCatalog::new(iceberg_catalog.clone(), None)
-            .await
-            .context(catalog_error::DataFusionSnafu)?;
+        let catalog = DataFusionIcebergCatalog::new_sync(iceberg_catalog.clone(), None);
         Ok(CachingCatalog::new(
             Arc::new(catalog),
             db.ident.to_string(),

--- a/crates/catalog/src/catalog_list.rs
+++ b/crates/catalog/src/catalog_list.rs
@@ -244,13 +244,11 @@ impl EmbucketCatalogList {
         );
 
         let catalog = DataFusionIcebergCatalog::new_sync(iceberg_catalog.clone(), None);
-        Ok(CachingCatalog::new(
-            Arc::new(catalog),
-            db.ident.to_string(),
-            Some(iceberg_catalog),
+        Ok(
+            CachingCatalog::new(Arc::new(catalog), db.ident.clone(), Some(iceberg_catalog))
+                .with_refresh(db.should_refresh)
+                .with_catalog_type(CatalogType::S3tables),
         )
-        .with_refresh(db.should_refresh)
-        .with_catalog_type(CatalogType::S3tables))
     }
 
     #[allow(clippy::as_conversions, clippy::too_many_lines)]

--- a/crates/catalog/src/schema.rs
+++ b/crates/catalog/src/schema.rs
@@ -40,14 +40,6 @@ impl SchemaProvider for CachingSchema {
     }
 
     fn table_names(&self) -> Vec<String> {
-        if !self.tables_cache.is_empty() {
-            // Don't fill the cache since should call async table() to fill it
-            return self
-                .tables_cache
-                .iter()
-                .map(|entry| entry.key().clone())
-                .collect();
-        }
         match &self.iceberg_catalog {
             Some(catalog) => {
                 let catalog = catalog.clone();

--- a/crates/catalog/src/schema.rs
+++ b/crates/catalog/src/schema.rs
@@ -55,10 +55,16 @@ impl SchemaProvider for CachingSchema {
                     return vec![];
                 };
                 block_on_without_deadlock(async move {
-                    catalog.list_tabulars(&namespace).await.map_or_else(
-                        |_| vec![],
-                        |namespaces| namespaces.into_iter().map(|ns| ns.to_string()).collect(),
-                    )
+                    catalog
+                        .list_tabulars(&namespace)
+                        .await
+                        .map(|tables| {
+                            tables
+                                .into_iter()
+                                .map(|identifier| identifier.name().to_owned())
+                                .collect()
+                        })
+                        .unwrap_or_default()
                 })
             }
             None => self.schema.table_names(),

--- a/crates/catalog/src/schema.rs
+++ b/crates/catalog/src/schema.rs
@@ -118,7 +118,7 @@ impl SchemaProvider for CachingSchema {
                 Ok::<Arc<dyn TableProvider>, DataFusionError>(table_provider)
             })?
         } else {
-            table
+            return self.schema.register_table(name, Arc::clone(&table));
         };
 
         let caching_table = Arc::new(CachingTable::new(name.clone(), Arc::clone(&table_provider)));

--- a/crates/catalog/src/tests/information_schema.rs
+++ b/crates/catalog/src/tests/information_schema.rs
@@ -3,7 +3,7 @@ use crate::information_schema::information_schema::{
     INFORMATION_SCHEMA, InformationSchemaProvider,
 };
 use crate::test_utils::sort_record_batch_by_sortable_columns;
-use catalog_metastore::{Config, InMemoryMetastore};
+use catalog_metastore::InMemoryMetastore;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::context::SessionContext;
 use datafusion::prelude::SessionConfig;


### PR DESCRIPTION
The main change
```DataFusionIcebergCatalog::new(iceberg_catalog.clone(), None)```
changed to 
```DataFusionIcebergCatalog::new_sync(iceberg_catalog.clone(), None)```
new_sync means that the catalog cache is empty during initialization