### PR TITLE
Attempt to fix stuck queries with additional errors propagation

### DIFF
--- a/crates/catalog/src/catalog.rs
+++ b/crates/catalog/src/catalog.rs
@@ -13,7 +13,7 @@ use iceberg_rust_spec::namespace::Namespace;
 use snafu::{OptionExt, ResultExt};
 use std::fmt::{Display, Formatter};
 use std::{any::Any, sync::Arc};
-use tracing::{error, warn};
+use tracing::error;
 
 #[derive(Clone)]
 pub struct CachingCatalog {

--- a/crates/catalog/src/catalogs/embucket/catalog.rs
+++ b/crates/catalog/src/catalogs/embucket/catalog.rs
@@ -1,9 +1,11 @@
 use super::schema::EmbucketSchema;
-use crate::block_on_without_deadlock;
+use crate::{block_in_new_runtime, error};
 use catalog_metastore::{Metastore, SchemaIdent};
 use datafusion::catalog::{CatalogProvider, SchemaProvider};
 use iceberg_rust::catalog::Catalog as IcebergCatalog;
+use snafu::ResultExt;
 use std::{any::Any, sync::Arc};
+use tracing::error;
 
 pub struct EmbucketCatalog {
     pub database: String,
@@ -50,16 +52,24 @@ impl CatalogProvider for EmbucketCatalog {
         let metastore = self.metastore.clone();
         let database = self.database.clone();
 
-        block_on_without_deadlock(async move {
-            metastore.list_schemas(&database).await.map_or_else(
-                |_| vec![],
-                |schemas| {
+        block_in_new_runtime(async move {
+            metastore
+                .list_schemas(&database)
+                .await
+                .map(|schemas| {
                     schemas
                         .into_iter()
                         .map(|s| s.ident.schema.clone())
                         .collect()
-                },
-            )
+                })
+                .context(error::MetastoreSnafu)
+        })
+        .unwrap_or_else(|error| {
+            error!(
+                ?error,
+                "Failed to list Iceberg namespaces; returning empty list"
+            );
+            vec![]
         })
     }
 
@@ -70,21 +80,26 @@ impl CatalogProvider for EmbucketCatalog {
         let database = self.database.clone();
         let schema_name = name.to_string();
 
-        block_on_without_deadlock(async move {
-            metastore
+        block_in_new_runtime(async move {
+            let schema_opt = metastore
                 .get_schema(&SchemaIdent::new(database.clone(), schema_name.clone()))
                 .await
-                .ok()
-                .flatten()
-                .map(|_| {
-                    let schema: Arc<dyn SchemaProvider> = Arc::new(EmbucketSchema {
-                        database,
-                        schema: schema_name,
-                        metastore,
-                        iceberg_catalog,
-                    });
-                    schema
-                })
+                .context(error::MetastoreSnafu)?;
+
+            let provider = schema_opt.map(|_| {
+                let schema: Arc<dyn SchemaProvider> = Arc::new(EmbucketSchema {
+                    database,
+                    schema: schema_name,
+                    metastore,
+                    iceberg_catalog,
+                });
+                schema
+            });
+            Ok(provider)
+        })
+        .unwrap_or_else(|error| {
+            error!(?error, "Failed to get schema; assuming missing");
+            None
         })
     }
 }

--- a/crates/catalog/src/error.rs
+++ b/crates/catalog/src/error.rs
@@ -1,5 +1,6 @@
 use datafusion_common::DataFusionError;
 use error_stack_trace;
+use iceberg_rust::error::Error as IcebergError;
 use iceberg_s3tables_catalog::error::Error as S3TablesError;
 use snafu::Location;
 use snafu::prelude::*;
@@ -66,6 +67,14 @@ pub enum Error {
     #[snafu(display("Missing volume with ident: '{name:?}'"))]
     MissingVolume {
         name: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Iceberg error: {error}"))]
+    Iceberg {
+        #[snafu(source(from(IcebergError, Box::new)))]
+        error: Box<IcebergError>,
         #[snafu(implicit)]
         location: Location,
     },

--- a/crates/catalog/src/lib.rs
+++ b/crates/catalog/src/lib.rs
@@ -26,7 +26,7 @@ where
 {
     let handle = std::thread::spawn(move || {
         // Try to create a dedicated Tokio runtime
-        let rt = Builder::new_current_thread()
+        let rt = Builder::new_multi_thread()
             .enable_all()
             .build()
             .context(error::CreateTokioRuntimeSnafu)?;

--- a/crates/executor/src/query.rs
+++ b/crates/executor/src/query.rs
@@ -1625,7 +1625,6 @@ impl UserQuery {
         };
 
         let catalog = self.get_catalog(&schema_ref.catalog)?;
-        println!("dddd {:?}", catalog.schema(&schema_ref.schema));
         if catalog.schema(&schema_ref.schema).is_some() {
             if if_not_exists {
                 return self.created_entity_response();

--- a/crates/executor/src/query.rs
+++ b/crates/executor/src/query.rs
@@ -1625,6 +1625,7 @@ impl UserQuery {
         };
 
         let catalog = self.get_catalog(&schema_ref.catalog)?;
+        println!("dddd {:?}", catalog.schema(&schema_ref.schema));
         if catalog.schema(&schema_ref.schema).is_some() {
             if if_not_exists {
                 return self.created_entity_response();


### PR DESCRIPTION
- moved back to block_in_new_runtime where we create a dedicated Tokio runtime
- added errors tracing to not silently skip errors