### PR TITLE
Lambda opentelemetry config support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ debug/
 target/
 data/
 
+.env.lambda
 .env
 metastore.yaml
 

--- a/config/.env.example
+++ b/config/.env.example
@@ -1,3 +1,4 @@
 METASTORE_CONFIG=config/metastore.yaml
 JWT_SECRET=secret
-TRACING_LEVEL=info
+TRACING_LEVEL=debug
+RUST_LOG=info

--- a/config/diesel.toml
+++ b/config/diesel.toml
@@ -1,5 +1,0 @@
-[migrations_directory]
-dir = "../crates/queries/migrations" 
-
-[print_schema]
-file = "../crates/queries/src/models/diesel_schema.rs"

--- a/config/otel-example.yaml
+++ b/config/otel-example.yaml
@@ -1,0 +1,25 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+      http:
+        endpoint: localhost:4318
+
+processors:
+  batch:
+
+exporters:
+  otlp:
+    endpoint: "${env:OTEL_EXPORTER_ENDPOINT}"
+    headers:
+      # explicit header example, feel free to set own set of headers in the same way
+      # everything can be hardcoded as well, without parametrization via env vars
+      x-honeycomb-team: "${env:OTEL_EXPORTER_API_KEY}"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp]

--- a/crates/embucket-lambda/Cargo.toml
+++ b/crates/embucket-lambda/Cargo.toml
@@ -59,4 +59,10 @@ timeout = 30
 tracing = "Active"
 # Note: include path is relative to workspace root
 # Must run deploy from workspace root: cargo lambda deploy --binary-name bootstrap
-include = ["config"]
+include = ["config/metastore.yaml"]
+
+[package.metadata.lambda.deploy.env]
+LOG_FORMAT = "json"
+METASTORE_CONFIG = "config/metastore.yaml"
+TRACING_LEVEL = "debug"
+RUST_LOG = "info"

--- a/crates/embucket-lambda/Makefile
+++ b/crates/embucket-lambda/Makefile
@@ -1,15 +1,23 @@
 .PHONY: build deploy test logs clean
 
-# Function name (override with: make deploy FUNCTION_NAME=your-function)
+# Following vars to be set externally:
+#  FUNCTION_NAME - override name of the lambda function
+#  ENV_FILE - override env file, relatively to project root
+#  FEATURES - cargo features to enable, comma separated
+#  LAYERS - additional layer ARNs to include, comma separated
+#  AWS_LAMBDA_ROLE_ARN - IAM role ARN for the lambda function
+#  WITH_OTEL_CONFIG - otel config path, file from <projectroot>/config/ dir
+
 FUNCTION_NAME ?= embucket-lambda
-ENV_FILE ?= config/.env
-AWS_LAMBDA_ROLE_ARN_PARAM := $(if $(AWS_LAMBDA_ROLE_ARN),--iam-role $(AWS_LAMBDA_ROLE_ARN))
-OTEL_COLLECTOR_LAYERS_PARAM := $(if $(OTEL_COLLECTOR_LAYERS),--layer-arn $(OTEL_COLLECTOR_LAYERS))
-# supported features: "streaming"
-FEATURES_PARAM := $(if $(FEATURES),--features $(FEATURES))
+ENV_FILE ?= config/.env.lambda
+OTEL_COLLECTOR_LAYER=arn:aws:lambda:us-east-2:184161586896:layer:opentelemetry-collector-arm64-0_19_0:1
+OTEL_CONFIG_ENV_PARAM=$(if $(WITH_OTEL_CONFIG),--env-var OPENTELEMETRY_COLLECTOR_CONFIG_URI=/var/task/$(WITH_OTEL_CONFIG))
 
 build:
-	cd ../.. && cargo lambda build --release -p embucket-lambda --arm64 -o zip --manifest-path crates/embucket-lambda/Cargo.toml $(FEATURES_PARAM)
+	cd ../.. && cargo lambda build --release -p embucket-lambda --arm64 \
+		$(if $(FEATURES),--features $(FEATURES)) \
+		$(if $(WITH_OTEL_CONFIG),--include $(WITH_OTEL_CONFIG)) \
+		-o zip --manifest-path crates/embucket-lambda/Cargo.toml
 
 # Deploy to AWS (must run from workspace root for include paths to work)
 deploy: build deploy-only public-url
@@ -17,22 +25,14 @@ deploy: build deploy-only public-url
 
 # Quick deploy without rebuild
 deploy-only:
-	cd ../.. && cargo lambda deploy $(OTEL_COLLECTOR_LAYERS_PARAM) $(AWS_LAMBDA_ROLE_ARN_PARAM) --env-file $(ENV_FILE) --binary-name bootstrap $(FUNCTION_NAME)
+	cd ../.. && cargo lambda deploy --admerge \
+		--env-file $(ENV_FILE) \
+		$(OTEL_CONFIG_ENV_PARAM) \
+		$(if $(WITH_OTEL_CONFIG),--layer-arn $(OTEL_COLLECTOR_LAYER)) \
+		$(if $(AWS_LAMBDA_ROLE_ARN),--iam-role $(AWS_LAMBDA_ROLE_ARN)) \
+		$(if $(LAYERS),--layer-arn $(LAYERS)) \
+		--binary-name bootstrap $(FUNCTION_NAME)
 	aws logs create-log-group --log-group-name "/aws/lambda/$(FUNCTION_NAME)" >/dev/null 2>&1 || true
-
-public-url:
-	@set -e; \
-	echo "Ensuring Function URL config exists for $(FUNCTION_NAME) (auth: NONE)..." ; \
-	aws lambda create-function-url-config --function-name "$(FUNCTION_NAME)" --auth-type NONE >/dev/null 2>&1 || \
-	  aws lambda update-function-url-config --function-name "$(FUNCTION_NAME)" --auth-type NONE >/dev/null ; \
-	echo "Ensuring public invoke permission exists..." ; \
-	aws lambda add-permission --function-name "$(FUNCTION_NAME)" \
-	  --statement-id AllowPublicURLInvoke \
-	  --action lambda:InvokeFunctionUrl \
-	  --principal "*" \
-	  --function-url-auth-type NONE >/dev/null 2>&1 || true ; \
-	URL="$$(aws lambda get-function-url-config --function-name "$(FUNCTION_NAME)" --query 'FunctionUrl' --output text)"; \
-	echo "$$URL"
 
 # Watch locally for development
 watch:
@@ -53,3 +53,34 @@ verify:
 # Clean build artifacts
 clean:
 	cargo clean
+
+###############################
+# Non-standard targets below #
+###############################
+
+public-url:
+	echo "Ensuring Function URL config exists for $(FUNCTION_NAME) (auth: NONE)..." ; \
+	aws lambda create-function-url-config \
+		--function-name "$(FUNCTION_NAME)" \
+		--auth-type NONE >/dev/null 2>&1 || \
+	  aws lambda update-function-url-config --function-name "$(FUNCTION_NAME)" --auth-type NONE >/dev/null ; \
+	echo "Ensuring public invoke permission exists..." ; \
+	aws lambda add-permission --function-name "$(FUNCTION_NAME)" \
+	  --statement-id AllowPublicURLInvoke \
+	  --action lambda:InvokeFunctionUrl \
+	  --principal "*" \
+	  --function-url-auth-type NONE >/dev/null 2>&1 || true ; \
+	URL="$$(aws lambda get-function-url-config --function-name "$(FUNCTION_NAME)" --query 'FunctionUrl' --output text)"; \
+	echo "$$URL"
+
+streaming: INVOKE_MODE=RESPONSE_STREAM
+streaming: invoke-mode
+
+buffered: INVOKE_MODE=BUFFERED
+buffered: invoke-mode
+
+invoke-mode:
+	echo "Enabling $(INVOKE_MODE) invoke mode for $(FUNCTION_NAME)..."
+	@aws lambda update-function-url-config \
+  		--function-name "$(FUNCTION_NAME)" \
+		--invoke-mode $(INVOKE_MODE)

--- a/crates/embucket-lambda/src/config.rs
+++ b/crates/embucket-lambda/src/config.rs
@@ -61,7 +61,7 @@ impl EnvConfig {
             object_store_connect_timeout_secs: parse_env("OBJECT_STORE_CONNECT_TIMEOUT_SECS")
                 .unwrap_or(3),
             otel_exporter_otlp_protocol: parse_env("OTEL_EXPORTER_OTLP_PROTOCOL")
-                .unwrap_or("grpc".to_string()),
+                .unwrap_or_else(|| "grpc".to_string()),
             tracing_level: env_or_default("TRACING_LEVEL", "INFO"),
         }
     }

--- a/crates/embucketd/src/main.rs
+++ b/crates/embucketd/src/main.rs
@@ -222,7 +222,7 @@ fn setup_tracing(opts: &cli::CliOpts) -> SdkTracerProvider {
                 .build()
                 .expect("Failed to create OTLP HTTP exporter")
         }
-        protocol => panic!("Unsupported OTLP protocol: {}", protocol),
+        protocol => panic!("Unsupported OTLP protocol: {protocol}"),
     };
 
     let resource = Resource::builder().with_service_name("Em").build();

--- a/crates/queries/README.md
+++ b/crates/queries/README.md
@@ -40,7 +40,15 @@ apt install -y libpq-dev
 Refer here how to install diesel cli:
 https://diesel.rs/guides/getting-started#installing-diesel-cli
 
-Diesel config is in repo root in `config/diesel.toml` file. 
+Put diesel config to the repo root into `config/diesel.toml`:
+```
+[migrations_directory]
+dir = "../crates/queries/migrations" 
+
+[print_schema]
+file = "../crates/queries/src/models/diesel_schema.rs"
+```
+
 
 Before running diesel cli set DATABASE_URL env var or create .env file:
 ```bash


### PR DESCRIPTION
* Changed logic of adding config files to deployment: Now they added explicitly instead of deploying entire config folder (arguable)
* Use cargo lambda `--admerge` merging lambda settings, particularly env vars added in `Cargo.toml`, `.env` file
* Added back envs section to Cargo.toml, since it supports merge
* lambda observability refactoring
* otel collector config as a part of lambda
* example of generic otel collector config, working with honeycomb
* streaming, buffered goals added to makefile to set lambda invoke_mode from cli

Also moved config file of postgres queries crate to related readme