### PR TITLE
Fix merge into compatability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3007,7 +3007,7 @@ dependencies = [
 [[package]]
 name = "datafusion_iceberg"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=814b086a6968516f5417839386c57d6dc4b9aee3#814b086a6968516f5417839386c57d6dc4b9aee3"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=493731eb85e1e04a79b82f97e96fd029ea271b15#493731eb85e1e04a79b82f97e96fd029ea271b15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4465,7 +4465,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rest-catalog"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=814b086a6968516f5417839386c57d6dc4b9aee3#814b086a6968516f5417839386c57d6dc4b9aee3"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=493731eb85e1e04a79b82f97e96fd029ea271b15#493731eb85e1e04a79b82f97e96fd029ea271b15"
 dependencies = [
  "async-trait",
  "aws-sigv4 0.3.1",
@@ -4490,7 +4490,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=814b086a6968516f5417839386c57d6dc4b9aee3#814b086a6968516f5417839386c57d6dc4b9aee3"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=493731eb85e1e04a79b82f97e96fd029ea271b15#493731eb85e1e04a79b82f97e96fd029ea271b15"
 dependencies = [
  "apache-avro",
  "arrow 56.2.0",
@@ -4526,7 +4526,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust-spec"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=814b086a6968516f5417839386c57d6dc4b9aee3#814b086a6968516f5417839386c57d6dc4b9aee3"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=493731eb85e1e04a79b82f97e96fd029ea271b15#493731eb85e1e04a79b82f97e96fd029ea271b15"
 dependencies = [
  "apache-avro",
  "arrow-schema 56.2.0",
@@ -4551,7 +4551,7 @@ dependencies = [
 [[package]]
 name = "iceberg-s3tables-catalog"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=814b086a6968516f5417839386c57d6dc4b9aee3#814b086a6968516f5417839386c57d6dc4b9aee3"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=493731eb85e1e04a79b82f97e96fd029ea271b15#493731eb85e1e04a79b82f97e96fd029ea271b15"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3007,7 +3007,7 @@ dependencies = [
 [[package]]
 name = "datafusion_iceberg"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=493731eb85e1e04a79b82f97e96fd029ea271b15#493731eb85e1e04a79b82f97e96fd029ea271b15"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=52aaae5d773ca4b0c619a2083c354ca23548151c#52aaae5d773ca4b0c619a2083c354ca23548151c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4465,7 +4465,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rest-catalog"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=493731eb85e1e04a79b82f97e96fd029ea271b15#493731eb85e1e04a79b82f97e96fd029ea271b15"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=52aaae5d773ca4b0c619a2083c354ca23548151c#52aaae5d773ca4b0c619a2083c354ca23548151c"
 dependencies = [
  "async-trait",
  "aws-sigv4 0.3.1",
@@ -4490,7 +4490,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=493731eb85e1e04a79b82f97e96fd029ea271b15#493731eb85e1e04a79b82f97e96fd029ea271b15"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=52aaae5d773ca4b0c619a2083c354ca23548151c#52aaae5d773ca4b0c619a2083c354ca23548151c"
 dependencies = [
  "apache-avro",
  "arrow 56.2.0",
@@ -4526,7 +4526,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust-spec"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=493731eb85e1e04a79b82f97e96fd029ea271b15#493731eb85e1e04a79b82f97e96fd029ea271b15"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=52aaae5d773ca4b0c619a2083c354ca23548151c#52aaae5d773ca4b0c619a2083c354ca23548151c"
 dependencies = [
  "apache-avro",
  "arrow-schema 56.2.0",
@@ -4551,7 +4551,7 @@ dependencies = [
 [[package]]
 name = "iceberg-s3tables-catalog"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=493731eb85e1e04a79b82f97e96fd029ea271b15#493731eb85e1e04a79b82f97e96fd029ea271b15"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=52aaae5d773ca4b0c619a2083c354ca23548151c#52aaae5d773ca4b0c619a2083c354ca23548151c"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3007,7 +3007,7 @@ dependencies = [
 [[package]]
 name = "datafusion_iceberg"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=a5fb43869d8c09d488343c24ea18db01752fb1bb#a5fb43869d8c09d488343c24ea18db01752fb1bb"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=814b086a6968516f5417839386c57d6dc4b9aee3#814b086a6968516f5417839386c57d6dc4b9aee3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4465,7 +4465,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rest-catalog"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=a5fb43869d8c09d488343c24ea18db01752fb1bb#a5fb43869d8c09d488343c24ea18db01752fb1bb"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=814b086a6968516f5417839386c57d6dc4b9aee3#814b086a6968516f5417839386c57d6dc4b9aee3"
 dependencies = [
  "async-trait",
  "aws-sigv4 0.3.1",
@@ -4490,7 +4490,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=a5fb43869d8c09d488343c24ea18db01752fb1bb#a5fb43869d8c09d488343c24ea18db01752fb1bb"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=814b086a6968516f5417839386c57d6dc4b9aee3#814b086a6968516f5417839386c57d6dc4b9aee3"
 dependencies = [
  "apache-avro",
  "arrow 56.2.0",
@@ -4526,7 +4526,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust-spec"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=a5fb43869d8c09d488343c24ea18db01752fb1bb#a5fb43869d8c09d488343c24ea18db01752fb1bb"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=814b086a6968516f5417839386c57d6dc4b9aee3#814b086a6968516f5417839386c57d6dc4b9aee3"
 dependencies = [
  "apache-avro",
  "arrow-schema 56.2.0",
@@ -4551,7 +4551,7 @@ dependencies = [
 [[package]]
 name = "iceberg-s3tables-catalog"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=a5fb43869d8c09d488343c24ea18db01752fb1bb#a5fb43869d8c09d488343c24ea18db01752fb1bb"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=814b086a6968516f5417839386c57d6dc4b9aee3#814b086a6968516f5417839386c57d6dc4b9aee3"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,15 +49,15 @@ datafusion-expr = { version = "50.0.0" }
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "439cbd2282504c3ffaf262f1ffdb530a0fb1a151" }
 datafusion-macros = { version = "50.0.0" }
 datafusion-physical-plan = { version = "50.0.0" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "493731eb85e1e04a79b82f97e96fd029ea271b15" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "af0532380770f55f23c783e555b4674cec743174" }
 futures = { version = "0.3" }
 http = "1.2"
 http-body-util = "0.1.0"
 iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev="7a5ad1fcaf00d4638857812bab788105f6c60573"}
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "493731eb85e1e04a79b82f97e96fd029ea271b15" }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "493731eb85e1e04a79b82f97e96fd029ea271b15" }
-iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "493731eb85e1e04a79b82f97e96fd029ea271b15" }
-iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "493731eb85e1e04a79b82f97e96fd029ea271b15" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "af0532380770f55f23c783e555b4674cec743174" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "af0532380770f55f23c783e555b4674cec743174" }
+iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "af0532380770f55f23c783e555b4674cec743174" }
+iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "af0532380770f55f23c783e555b4674cec743174" }
 indexmap = "2.7.1"
 jsonwebtoken = "9.3.1"
 lazy_static = { version = "1.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,15 +49,15 @@ datafusion-expr = { version = "50.0.0" }
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "439cbd2282504c3ffaf262f1ffdb530a0fb1a151" }
 datafusion-macros = { version = "50.0.0" }
 datafusion-physical-plan = { version = "50.0.0" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "814b086a6968516f5417839386c57d6dc4b9aee3" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "493731eb85e1e04a79b82f97e96fd029ea271b15" }
 futures = { version = "0.3" }
 http = "1.2"
 http-body-util = "0.1.0"
 iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev="7a5ad1fcaf00d4638857812bab788105f6c60573"}
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "814b086a6968516f5417839386c57d6dc4b9aee3" }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "814b086a6968516f5417839386c57d6dc4b9aee3" }
-iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "814b086a6968516f5417839386c57d6dc4b9aee3" }
-iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "814b086a6968516f5417839386c57d6dc4b9aee3" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "493731eb85e1e04a79b82f97e96fd029ea271b15" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "493731eb85e1e04a79b82f97e96fd029ea271b15" }
+iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "493731eb85e1e04a79b82f97e96fd029ea271b15" }
+iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "493731eb85e1e04a79b82f97e96fd029ea271b15" }
 indexmap = "2.7.1"
 jsonwebtoken = "9.3.1"
 lazy_static = { version = "1.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,15 +49,15 @@ datafusion-expr = { version = "50.0.0" }
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "439cbd2282504c3ffaf262f1ffdb530a0fb1a151" }
 datafusion-macros = { version = "50.0.0" }
 datafusion-physical-plan = { version = "50.0.0" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "a5fb43869d8c09d488343c24ea18db01752fb1bb" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "814b086a6968516f5417839386c57d6dc4b9aee3" }
 futures = { version = "0.3" }
 http = "1.2"
 http-body-util = "0.1.0"
 iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev="7a5ad1fcaf00d4638857812bab788105f6c60573"}
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "a5fb43869d8c09d488343c24ea18db01752fb1bb" }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "a5fb43869d8c09d488343c24ea18db01752fb1bb" }
-iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "a5fb43869d8c09d488343c24ea18db01752fb1bb" }
-iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "a5fb43869d8c09d488343c24ea18db01752fb1bb" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "814b086a6968516f5417839386c57d6dc4b9aee3" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "814b086a6968516f5417839386c57d6dc4b9aee3" }
+iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "814b086a6968516f5417839386c57d6dc4b9aee3" }
+iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "814b086a6968516f5417839386c57d6dc4b9aee3" }
 indexmap = "2.7.1"
 jsonwebtoken = "9.3.1"
 lazy_static = { version = "1.5" }


### PR DESCRIPTION
Based on https://github.com/Embucket/iceberg-rust/pull/52 and
https://github.com/Embucket/iceberg-rust/pull/53

- for overwrite operation we need to save filtered data files for compatability with other iceberg engines since they take into account all deteled data files and stats within current snapshot 
**Spark** and**Snowflake** create additional manifest to track all deleted files for compatability
```Record 1:
  manifest_path: s3://...-m1.avro
  manifest_length: 7944
  partition_spec_id: 0
  content: 0
  sequence_number: 2
  min_sequence_number: 2
  added_snapshot_id: 8234522747398339109
  added_files_count: 1
  existing_files_count: 0
  deleted_files_count: 0
  added_rows_count: 6001215
  existing_rows_count: 0
  deleted_rows_count: 0
  partitions: []
  key_metadata: None

Record 2:
  manifest_path: s3://...-m0.avro
  manifest_length: 7942
  partition_spec_id: 0
  content: 0
  sequence_number: 2
  min_sequence_number: 2
  added_snapshot_id: 8234522747398339109
  added_files_count: 0
  existing_files_count: 0
  deleted_files_count: 1
  added_rows_count: 0
  existing_rows_count: 0
  deleted_rows_count: 6001215
  partitions: []
  key_metadata: None
```
- this mechanism can be also used in future to restore removed data