### PR TITLE
Save flatten DDB model instead of DATA json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7001,6 +7001,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_dynamo"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873a97c3f7a67dd042bceb47d056d288424b82d4c66b0a25e1a3b34675620951"
+dependencies = [
+ "aws-sdk-dynamodb",
+ "base64 0.21.7",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7319,6 +7331,7 @@ dependencies = [
  "error-stack-trace",
  "mockall",
  "serde",
+ "serde_dynamo",
  "serde_json",
  "snafu",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ regex = "1.11.1"
 serde = { version = "1.0.228", features = ["derive", "alloc"] }
 serde_json = { version = "1.0.145", features = ["raw_value"]}
 serde_yaml = "0.9"
+serde_dynamo = { version = "4.3.0", features = ["aws-sdk-dynamodb+1"] }
 snafu = { version = "0.8.5", features = ["futures"] }
 tikv-jemallocator = { version = "0.6.0" }
 strum = { version = "0.27.2", features = ["derive"] }

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 license-file.workspace = true
 
 [features]
-default = []
+default = ["state-store-query"]
 rest-catalog = ["catalog/rest-catalog"]
 dedicated-executor = []
 

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 license-file.workspace = true
 
 [features]
-default = ["state-store-query"]
+default = []
 rest-catalog = ["catalog/rest-catalog"]
 dedicated-executor = []
 

--- a/crates/executor/src/query_task_result.rs
+++ b/crates/executor/src/query_task_result.rs
@@ -5,6 +5,7 @@ use super::models::QueryResult;
 use super::query_types::ExecutionStatus;
 use super::snowflake_error::SnowflakeError;
 use snafu::ResultExt;
+#[cfg(feature = "state-store-query")]
 use state_store::QueryMetric;
 use tokio::task::JoinError;
 use uuid::Uuid;

--- a/crates/state-store/Cargo.toml
+++ b/crates/state-store/Cargo.toml
@@ -14,6 +14,7 @@ aws-credential-types = { workspace = true }
 aws-sdk-dynamodb = { workspace = true }
 serde = { workspace = true }
 serde_json = {workspace = true}
+serde_dynamo = { workspace = true }
 snafu = { workspace = true }
 chrono = { workspace = true }
 mockall = { workspace = true }

--- a/crates/state-store/src/error.rs
+++ b/crates/state-store/src/error.rs
@@ -4,6 +4,7 @@ use aws_sdk_dynamodb::operation::delete_item::DeleteItemError;
 use aws_sdk_dynamodb::operation::get_item::GetItemError;
 use aws_sdk_dynamodb::operation::put_item::PutItemError;
 use aws_sdk_dynamodb::operation::query::QueryError;
+use serde_dynamo::Error as SerdeDynamoError;
 use snafu::{Location, Snafu};
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -54,6 +55,20 @@ pub enum Error {
     DynamoDbCredentialsError {
         #[snafu(source(from(aws_credential_types::provider::error::CredentialsError, Box::new)))]
         error: Box<aws_credential_types::provider::error::CredentialsError>,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to serialize DynamoDB item: {error}"))]
+    FailedToSerializeDynamo {
+        #[snafu(source)]
+        error: SerdeDynamoError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to deserialize DynamoDB item: {error}"))]
+    FailedToDeserializeDynamo {
+        #[snafu(source)]
+        error: SerdeDynamoError,
         #[snafu(implicit)]
         location: Location,
     },


### PR DESCRIPTION
- Flattened session and query writes to DynamoDB by storing model fields as individual attributes instead of a JSON blob, enabling filtering on columns.
```
{
  "query_hash_version": 1,
  "Entity": "query",
  "warehouse_type": "EMBUCKET",
  "query_id": "019b9a21-cdee-7103-b582-7ff0ed921b4c",
  "database_name": "embucket",
  "end_time": "2026-01-07T20:24:27.879777452Z",
  "session_id": "609460f3-322f-4e76-bf31-c1af6a6e38e0",
  "schema_name": "public",
  "execution_time": 2553,
  "start_time": "2026-01-07T20:24:25.326438536Z",
  "query_hash": "558958833988661941",
  "execution_status": "Success",
  "SK": "1767817465326",
  "query_metrics": [
    {
      "metrics": [
        {
          "name": "start_timestamp",
          "partition": {
            "$serde_json::private::Number": "0"
          },
          "value": {
            "$serde_json::private::Number": "1767817466770622315"
          },
          "labels": {},
          "display": "2026-01-07 20:24:26.770622315 UTC"
        },
        {
          "name": "end_timestamp",
          "partition": {
            "$serde_json::private::Number": "0"
          },
          "value": {
            "$serde_json::private::Number": "1767817467879269378"
          },
          "display": "2026-01-07 20:24:27.879269378 UTC",
          "labels": {}
        }
        ...
  ],
  "PK": "QUERY#2026-01-07",
  "request_id": "4441960e-35eb-44f5-b949-924954ce2f92",
  "query_text": "SELECT * FROM embucket.tpch.t1 ORDER BY a,b,c;"
}
```