### PR TITLE
query completion attrs3

### DIFF
--- a/crates/api-snowflake-rest-sessions/src/helpers.rs
+++ b/crates/api-snowflake-rest-sessions/src/helpers.rs
@@ -1,8 +1,8 @@
+use super::TokenizedSession;
 use chrono::offset::Local;
 use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation, decode, encode};
 use serde::{Deserialize, Serialize};
 use time::Duration;
-use uuid::Uuid;
 
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(test, derive(Debug))]
@@ -11,11 +11,16 @@ pub struct Claims {
     pub aud: String, // validate audience since as it can be deployed on multiple hosts
     pub iat: i64,    // Issued At
     pub exp: i64,    // Expiration Time
-    pub session_id: String,
+    pub session: TokenizedSession,
 }
 
 #[must_use]
-pub fn jwt_claims(username: &str, audience: &str, expiration: Duration) -> Claims {
+pub fn jwt_claims(
+    username: &str,
+    audience: &str,
+    expiration: Duration,
+    session: TokenizedSession,
+) -> Claims {
     let now = Local::now();
     let iat = now.timestamp();
     let exp = now.timestamp() + expiration.whole_seconds();
@@ -25,7 +30,7 @@ pub fn jwt_claims(username: &str, audience: &str, expiration: Duration) -> Claim
         aud: audience.to_string(),
         iat,
         exp,
-        session_id: Uuid::new_v4().to_string(),
+        session,
     }
 }
 

--- a/crates/api-snowflake-rest-sessions/src/lib.rs
+++ b/crates/api-snowflake-rest-sessions/src/lib.rs
@@ -3,4 +3,4 @@ pub mod helpers;
 pub mod layer;
 pub mod session;
 
-pub use crate::session::DFSessionId;
+pub use crate::session::TokenizedSession;

--- a/crates/api-snowflake-rest/src/models.rs
+++ b/crates/api-snowflake-rest/src/models.rs
@@ -56,6 +56,7 @@ pub struct QueryRequest {
 pub struct QueryRequestBody {
     pub sql_text: String,
     pub async_exec: Option<bool>,
+    pub query_submission_time: Option<u64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/api-snowflake-rest/src/server/handlers.rs
+++ b/crates/api-snowflake-rest/src/server/handlers.rs
@@ -5,7 +5,7 @@ use crate::models::{
 };
 use crate::server::error::Result;
 use crate::server::logic::{handle_login_request, handle_query_request};
-use api_snowflake_rest_sessions::DFSessionId;
+use api_snowflake_rest_sessions::TokenizedSession;
 use api_snowflake_rest_sessions::layer::Host;
 use axum::Json;
 use axum::extract::{ConnectInfo, Query, State};
@@ -52,14 +52,14 @@ pub async fn login(
 )]
 pub async fn query(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
-    DFSessionId(session_id): DFSessionId,
+    tokenized_session: TokenizedSession,
     State(state): State<AppState>,
     Query(query): Query<QueryRequest>,
     Json(query_body): Json<QueryRequestBody>,
 ) -> Result<Json<JsonResponse>> {
     let response = handle_query_request(
         &state,
-        &session_id,
+        tokenized_session,
         query,
         query_body,
         Option::from(addr.ip().to_string()),
@@ -93,7 +93,7 @@ pub async fn abort(
     ret(level = tracing::Level::TRACE)
 )]
 pub async fn session(
-    DFSessionId(session_id): DFSessionId,
+    TokenizedSession(session_id, ..): TokenizedSession,
     State(state): State<AppState>,
     Query(query_params): Query<SessionQueryParams>,
 ) -> Result<Json<serde_json::value::Value>> {

--- a/crates/api-snowflake-rest/src/server/layer.rs
+++ b/crates/api-snowflake-rest/src/server/layer.rs
@@ -40,7 +40,7 @@ pub async fn require_auth(
         get_claims_validate_jwt_token(&token, &host, &jwt_secret).context(BadAuthTokenSnafu)?;
 
     // Record the result as part of the current span.
-    tracing::Span::current().record("session_id", jwt_claims.session_id.as_str());
+    tracing::Span::current().record("session_id", jwt_claims.session.session_id());
 
     let response = next.run(req).await;
 

--- a/crates/api-snowflake-rest/src/server/logic.rs
+++ b/crates/api-snowflake-rest/src/server/logic.rs
@@ -4,21 +4,23 @@ use crate::models::{
     QueryRequest, QueryRequestBody,
 };
 use crate::server::error::{
-    self as api_snowflake_rest_error, CreateJwtSnafu, NoJwtSecretSnafu, Result, SetVariableSnafu,
+    self as api_snowflake_rest_error, CreateJwtSnafu, NoJwtSecretSnafu, Result,
 };
 use crate::server::helpers::handle_query_ok_result;
+use api_snowflake_rest_sessions::TokenizedSession;
 use api_snowflake_rest_sessions::helpers::{create_jwt, ensure_jwt_secret_is_valid, jwt_claims};
 use executor::RunningQueryId;
-use executor::models::QueryContext;
+use executor::models::{QueryContext, SessionMetadata, SessionMetadataAttr};
 use snafu::{OptionExt, ResultExt};
 use time::Duration;
 
 pub const JWT_TOKEN_EXPIRATION_SECONDS: u32 = 3 * 24 * 60 * 60;
 
 #[tracing::instrument(
-    name = "api_snowflake_rest::logic::login",
+    name = "api_snowflake_rest::handle_login_request",
     level = "debug",
     skip(state, credentials),
+    fields(session_metadata),
     err,
     ret(level = tracing::Level::TRACE)
 )]
@@ -32,6 +34,9 @@ pub async fn handle_login_request(
     let LoginRequestData {
         login_name,
         password,
+        account_name,
+        client_app_id,
+        client_app_version,
         ..
     } = credentials;
 
@@ -43,39 +48,39 @@ pub async fn handle_login_request(
     let jwt_secret = &*state.config.auth.jwt_secret;
     let _ = ensure_jwt_secret_is_valid(jwt_secret).context(NoJwtSecretSnafu)?;
 
+    let mut session_metadata = SessionMetadata::default();
+    session_metadata.set_attr(SessionMetadataAttr::UserName, login_name.clone());
+    session_metadata.set_attr(SessionMetadataAttr::AccountName, account_name);
+    session_metadata.set_attr(SessionMetadataAttr::ClientAppId, client_app_id);
+    session_metadata.set_attr(SessionMetadataAttr::ClientAppVersion, client_app_version);
+    // set database, schema when provided
+    if let Some(db) = params.database_name {
+        session_metadata.set_attr(SessionMetadataAttr::Database, db);
+    }
+    if let Some(schema) = params.schema_name {
+        session_metadata.set_attr(SessionMetadataAttr::Schema, schema);
+    }
+    if let Some(warehouse) = params.warehouse {
+        session_metadata.set_attr(SessionMetadataAttr::Warehouse, warehouse);
+    }
+
+    tracing::Span::current().record("session_metadata", format!("{session_metadata:?}"));
+
+    let tokenized_session = TokenizedSession::default().with_metadata(session_metadata);
+
     let jwt_claims = jwt_claims(
         &login_name,
         &host,
         Duration::seconds(JWT_TOKEN_EXPIRATION_SECONDS.into()),
+        tokenized_session,
     );
 
     tracing::info!("Host '{host}' for token creation");
 
-    let session_id = jwt_claims.session_id.clone();
-    let session = state.execution_svc.create_session(&session_id).await?;
+    let session_id = jwt_claims.session.session_id();
+    let _session = state.execution_svc.create_session(session_id).await?;
 
     let jwt_token = create_jwt(&jwt_claims, jwt_secret).context(CreateJwtSnafu)?;
-
-    // set database, schema when provided
-    if let Some(db) = params.database_name {
-        session.set_database(&db).await.context(SetVariableSnafu {
-            variable: "database",
-        })?;
-    }
-    if let Some(schema) = params.schema_name {
-        session
-            .set_schema(&schema)
-            .await
-            .context(SetVariableSnafu { variable: "schema" })?;
-    }
-    if let Some(warehouse) = params.warehouse {
-        session
-            .set_warehouse(&warehouse)
-            .await
-            .context(SetVariableSnafu {
-                variable: "warehouse",
-            })?;
-    }
 
     Ok(LoginResponse {
         data: Option::from(LoginResponseData { token: jwt_token }),
@@ -85,7 +90,7 @@ pub async fn handle_login_request(
 }
 
 #[tracing::instrument(
-    name = "api_snowflake_rest::logic::query",
+    name = "api_snowflake_rest::handle_query_request",
     level = "debug",
     skip(state, query_body, client_ip),
     fields(request_id = %query.request_id),
@@ -94,7 +99,7 @@ pub async fn handle_login_request(
 )]
 pub async fn handle_query_request(
     state: &AppState,
-    session_id: &str,
+    TokenizedSession(session_id, session_metadata): TokenizedSession,
     query: QueryRequest,
     query_body: QueryRequestBody,
     client_ip: Option<String>,
@@ -102,6 +107,7 @@ pub async fn handle_query_request(
     let QueryRequestBody {
         sql_text,
         async_exec,
+        query_submission_time,
     } = query_body;
     let async_exec = async_exec.unwrap_or(false);
     if async_exec {
@@ -109,7 +115,13 @@ pub async fn handle_query_request(
     }
 
     let serialization_format = state.config.dbt_serialization_format;
-    let mut query_context = QueryContext::default().with_request_id(query.request_id);
+    let mut query_context = QueryContext::new(
+        session_metadata.attr(SessionMetadataAttr::Database),
+        session_metadata.attr(SessionMetadataAttr::Schema),
+        None,
+    )
+    .with_request_id(query.request_id)
+    .with_query_submission_time(query_submission_time);
 
     if let Some(ip) = client_ip {
         query_context = query_context.with_ip_address(ip);
@@ -123,7 +135,7 @@ pub async fn handle_query_request(
             sql_text.clone(),
         ));
 
-    // if retry-disable feature is enabled we ignory retries regardless of query_id is located or not
+    // if retry-disable feature is enabled we ignore retries regardless of query_id is located or not
     #[cfg(feature = "retry-disable")]
     if query.retry_count.unwrap_or_default() > 0 {
         return api_snowflake_rest_error::RetryDisabledSnafu.fail();
@@ -138,7 +150,7 @@ pub async fn handle_query_request(
         let query_id = query_context.query_id;
         let result = state
             .execution_svc
-            .query(session_id, &sql_text, query_context)
+            .query(&session_id, &sql_text, query_context)
             .await?;
         (result, query_id)
     };

--- a/crates/api-snowflake-rest/src/server/logic.rs
+++ b/crates/api-snowflake-rest/src/server/logic.rs
@@ -121,7 +121,8 @@ pub async fn handle_query_request(
         None,
     )
     .with_request_id(query.request_id)
-    .with_query_submission_time(query_submission_time);
+    .with_query_submission_time(query_submission_time)
+    .with_session_metadata(Some(session_metadata));
 
     if let Some(ip) = client_ip {
         query_context = query_context.with_ip_address(ip);

--- a/crates/api-snowflake-rest/src/tests/client.rs
+++ b/crates/api-snowflake-rest/src/tests/client.rs
@@ -204,6 +204,7 @@ where
         json!(QueryRequestBody {
             sql_text: query.to_string(),
             async_exec: Some(async_exec),
+            query_submission_time: Some(1_764_161_275_445),
         })
         .to_string(),
     )

--- a/crates/api-snowflake-rest/src/tests/snapshots/compatible/set_command_show_variables.snap
+++ b/crates/api-snowflake-rest/src/tests/snapshots/compatible/set_command_show_variables.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/api-snowflake-rest/src/tests/test_rest_api.rs
-description: "SQL #2 [spent: 834/2246ms]: SHOW VARIABLES\nQuery UUID: 019ba0a2-81a9-7f01-8831-0ab6e9cef96c"
+description: "SQL #1 [spent: 1028/1653ms]: SHOW VARIABLES\nQuery UUID: 019ba0a2-7c9d-7f31-accb-d20a0622ba57"
 expression: snapshot
 ---
 SHOW VARIABLES

--- a/crates/api-snowflake-rest/src/tests/sql_test_macro.rs
+++ b/crates/api-snowflake-rest/src/tests/sql_test_macro.rs
@@ -5,6 +5,7 @@ use crate::tests::TEST_JWT_SECRET;
 use crate::tests::snow_sql::{ACCESS_TOKEN_KEY, snow_sql};
 use crate::tests::snow_sql::{PASSWORD_KEY, REQUEST_ID_KEY, USER_KEY};
 use crate::{models::JsonResponse, server::server_models::RestApiConfig};
+use api_snowflake_rest_sessions::TokenizedSession;
 use api_snowflake_rest_sessions::helpers::{create_jwt, jwt_claims};
 use arrow::record_batch::RecordBatch;
 use catalog_metastore::metastore_settings_config::MetastoreSettingsConfig;
@@ -171,6 +172,7 @@ impl SqlTest {
             DEMO_USER,
             &host,
             time::Duration::seconds(JWT_TOKEN_EXPIRATION_SECONDS.into()),
+            TokenizedSession::default(),
         );
 
         create_jwt(&jwt_claims, jwt_secret).expect("Failed to create JWT token")

--- a/crates/api-snowflake-rest/src/tests/test_gzip_encoding.rs
+++ b/crates/api-snowflake-rest/src/tests/test_gzip_encoding.rs
@@ -27,6 +27,7 @@ mod tests {
         let query_request = QueryRequestBody {
             sql_text: "SELECT 1;".to_string(),
             async_exec: Some(false),
+            query_submission_time: Some(1_764_161_275_445),
         };
 
         let query_compressed_bytes = make_bytes_body(&query_request);

--- a/crates/api-snowflake-rest/src/tests/test_rest_api.rs
+++ b/crates/api-snowflake-rest/src/tests/test_rest_api.rs
@@ -87,6 +87,11 @@ mod compatible {
     );
 
     sql_test!(
+        set_command_show_variables,
+        SqlTest::new(&["SHOW VARIABLES"]).with_setup_queries(&["set variable_name = 'value'"])
+    );
+
+    sql_test!(
         create_table_missing_schema,
         SqlTest::new(&[
             // "Snowflake:

--- a/crates/embucket-lambda/Cargo.toml
+++ b/crates/embucket-lambda/Cargo.toml
@@ -45,6 +45,7 @@ retry-disable = ["api-snowflake-rest/retry-disable"]
 streaming = []
 rest-catalog = ["executor/rest-catalog"]
 dedicated-executor = ["executor/dedicated-executor"]
+state-store-persist-session-oncreate = ["executor/state-store-persist-session-oncreate"]
 state-store-query = ["executor/state-store-query"]
 
 [package.metadata.lambda]

--- a/crates/embucketd/Cargo.toml
+++ b/crates/embucketd/Cargo.toml
@@ -52,6 +52,8 @@ retry-disable = ["api-snowflake-rest/retry-disable"]
 rest-catalog = ["executor/rest-catalog"]
 dedicated-executor = ["executor/dedicated-executor"]
 state-store = ["executor/state-store"]
+state-store-persist-session-oncreate = ["executor/state-store-persist-session-oncreate"]
 state-store-query = ["executor/state-store-query"]
 state-store-query-test = ["executor/state-store-query-test"]
+
 

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -12,6 +12,10 @@ dedicated-executor = []
 # "state-store" feature enables DynamoDB based state-store implementation.
 state-store = []
 
+# "state-store-persist-session-oncreate" feature allows to persist empty session record.
+# Otherwise it will be persisted only if session has something to persist.
+state-store-persist-session-oncreate = ["state-store"]
+
 state-store-query-test = ["state-store-query"]
 
 # "state-store-query" feature depends on state-store feature.

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -19,7 +19,7 @@ pub mod utils;
 pub mod tests;
 
 pub use error::{Error, Result};
-pub use models::{SessionMetadata, SessionMetadataAttr};
+pub use models::{QueryResult, SessionMetadata, SessionMetadataAttr};
 pub use query_types::{ExecutionStatus, QueryId};
 pub use running_queries::RunningQueryId;
 pub use snowflake_error::SnowflakeError;

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -19,6 +19,7 @@ pub mod utils;
 pub mod tests;
 
 pub use error::{Error, Result};
+pub use models::{SessionMetadata, SessionMetadataAttr};
 pub use query_types::{ExecutionStatus, QueryId};
 pub use running_queries::RunningQueryId;
 pub use snowflake_error::SnowflakeError;

--- a/crates/executor/src/models.rs
+++ b/crates/executor/src/models.rs
@@ -18,6 +18,8 @@ pub struct QueryContext {
     pub query_id: QueryId,
     pub request_id: Option<Uuid>,
     pub ip_address: Option<String>,
+    pub query_submission_time: Option<u64>,
+    pub session_metadata: Option<SessionMetadata>,
 }
 
 // Add own Default implementation to avoid getting default (zeroed) Uuid.
@@ -31,6 +33,8 @@ impl Default for QueryContext {
             query_id: Uuid::now_v7(),
             request_id: None,
             ip_address: None,
+            query_submission_time: None,
+            session_metadata: None,
         }
     }
 }
@@ -65,6 +69,18 @@ impl QueryContext {
     #[must_use]
     pub fn with_ip_address(mut self, ip_address: String) -> Self {
         self.ip_address = Some(ip_address);
+        self
+    }
+
+    #[must_use]
+    pub const fn with_query_submission_time(mut self, query_submission_time: Option<u64>) -> Self {
+        self.query_submission_time = query_submission_time;
+        self
+    }
+
+    #[must_use]
+    pub fn with_session_metadata(mut self, session_metadata: Option<SessionMetadata>) -> Self {
+        self.session_metadata = session_metadata;
         self
     }
 }
@@ -129,6 +145,32 @@ impl QueryMetric {
             operator: operator.to_string(),
             metrics,
         }
+    }
+}
+
+#[derive(strum::Display, Clone, Copy)]
+pub enum SessionMetadataAttr {
+    UserName,
+    Warehouse,
+    Database,
+    Schema,
+    AccountName,
+    ClientAppId,
+    ClientAppVersion,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct SessionMetadata(HashMap<String, String>);
+
+impl SessionMetadata {
+    pub fn set_attr(&mut self, attr: SessionMetadataAttr, value: String) {
+        self.0.insert(attr.to_string(), value);
+    }
+
+    #[must_use]
+    pub fn attr(&self, attr: SessionMetadataAttr) -> Option<String> {
+        self.0.get(&attr.to_string()).cloned()
     }
 }
 

--- a/crates/executor/src/query.rs
+++ b/crates/executor/src/query.rs
@@ -312,10 +312,16 @@ impl UserQuery {
                 Statement::ShowTables { .. } => save(QueryType::Misc(MiscStType::ShowTables)),
                 Statement::ShowViews { .. } => save(QueryType::Misc(MiscStType::ShowViews)),
                 Statement::ExplainTable { .. } => save(QueryType::Misc(MiscStType::ExplainTable)),
+                Statement::Explain { .. } => save(QueryType::Misc(MiscStType::Explain)),
+                Statement::Analyze { .. } => save(QueryType::Misc(MiscStType::Analyze)),
                 _ => {}
             }
         } else if let DFStatement::CreateExternalTable(..) = statement {
             save(QueryType::Ddl(DdlStType::CreateExternalTable));
+        } else if let DFStatement::Explain(..) = statement {
+            save(QueryType::Misc(MiscStType::Explain));
+        } else if let DFStatement::CopyTo(..) = statement {
+            save(QueryType::Misc(MiscStType::CopyTo));
         }
     }
 

--- a/crates/executor/src/query.rs
+++ b/crates/executor/src/query.rs
@@ -155,19 +155,17 @@ impl UserQuery {
 
     #[must_use]
     pub fn current_database(&self) -> String {
-        self.query_context
-            .database
-            .clone()
-            .or_else(|| self.session.get_session_variable("database"))
+        self.session
+            .get_session_variable("database")
+            .or_else(|| self.query_context.database.clone())
             .unwrap_or_else(|| "embucket".to_string())
     }
 
     #[must_use]
     pub fn current_schema(&self) -> String {
-        self.query_context
-            .schema
-            .clone()
-            .or_else(|| self.session.get_session_variable("schema"))
+        self.session
+            .get_session_variable("schema")
+            .or_else(|| self.query_context.schema.clone())
             .unwrap_or_else(|| "public".to_string())
     }
 

--- a/crates/executor/src/query_types.rs
+++ b/crates/executor/src/query_types.rs
@@ -68,6 +68,9 @@ pub enum MiscStType {
     ShowTables,
     ShowViews,
     ExplainTable,
+    Explain,
+    Analyze,
+    CopyTo,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/executor/src/service.rs
+++ b/crates/executor/src/service.rs
@@ -25,6 +25,8 @@ use tokio::task;
 use tokio_util::sync::CancellationToken;
 
 use super::error::{self as ex_error, Result};
+#[cfg(feature = "state-store")]
+use super::models::SessionMetadataAttr;
 use super::models::{QueryContext, QueryResult};
 use super::running_queries::{RunningQueries, RunningQueriesRegistry, RunningQuery};
 use super::session::UserSession;
@@ -319,11 +321,11 @@ impl ExecutionService for CoreExecutionService {
             tracing::trace!("Acquired write lock for df_sessions");
             sessions.insert(session_id.to_string(), user_session.clone());
 
-            #[cfg(feature = "state-store")]
-            self.state_store
-                .put_new_session(session_id)
-                .await
-                .context(ex_error::StateStoreSnafu)?;
+            // #[cfg(feature = "state-store")]
+            // self.state_store
+            //     .put_new_session(session_id)
+            //     .await
+            //     .context(ex_error::StateStoreSnafu)?;
 
             // Record the result as part of the current span.
             tracing::Span::current().record("new_sessions_count", sessions.len());
@@ -529,6 +531,27 @@ impl ExecutionService for CoreExecutionService {
                 query.set_execution_status(ExecutionStatus::Running);
                 query.set_warehouse_type(self.config.warehouse_type.clone());
                 query.set_release_version(self.config.build_version.clone());
+                // session context set by user during login
+                if let Some(database) = &query_context.database {
+                    query.set_user_database(database.clone());
+                }
+                if let Some(schema) = &query_context.schema {
+                    query.set_user_schema(schema.clone());
+                }
+                if let Some(query_submission_time) = &query_context.query_submission_time {
+                    query.set_query_submission_time(*query_submission_time);
+                }
+                if let Some(session_metadata) = &query_context.session_metadata {
+                    if let Some(user_name) = session_metadata.attr(SessionMetadataAttr::UserName) {
+                        query.set_user_name(user_name);
+                    }
+                    if let Some(client_app_id) = session_metadata.attr(SessionMetadataAttr::ClientAppId) {
+                        query.set_client_app_id(client_app_id);
+                    }
+                    if let Some(client_app_version) = session_metadata.attr(SessionMetadataAttr::ClientAppVersion) {
+                        query.set_client_app_version(client_app_version);
+                    }
+                }
             }
         }
 
@@ -581,7 +604,7 @@ impl ExecutionService for CoreExecutionService {
                 let mut query_obj = user_session.query(query_text, query_context);
                 #[cfg(feature = "state-store-query")]
                 {
-                    // current database/schema at planning/execution time
+                    // effective database/schema at planning/execution time
                     query.set_database_name(query_obj.current_database());
                     query.set_schema_name(query_obj.current_schema());
                 }
@@ -630,11 +653,9 @@ impl ExecutionService for CoreExecutionService {
                 cfg_if::cfg_if! {
                     if #[cfg(feature = "state-store-query")] {
                         execution_result.assign_query_attributes(&mut query);
-                        if let Some(stats) = queries_registry.cloned_stats(query_id) {
-                            if let Some(query_type) = stats.query_type {
-                                query.set_query_type(query_type.to_string());
-                                execution_result.assign_rows_counts_attributes(&mut query, query_type);
-                            }
+                        if let Some(stats) = queries_registry.cloned_stats(query_id) && let Some(query_type) = stats.query_type {
+                            query.set_query_type(query_type.to_string());
+                            execution_result.assign_rows_counts_attributes(&mut query, query_type);
                         }
                         // just log error and do not raise it from task
                         if let Err(err) = state_store.update_query(&query).await {

--- a/crates/executor/src/service.rs
+++ b/crates/executor/src/service.rs
@@ -321,11 +321,11 @@ impl ExecutionService for CoreExecutionService {
             tracing::trace!("Acquired write lock for df_sessions");
             sessions.insert(session_id.to_string(), user_session.clone());
 
-            // #[cfg(feature = "state-store")]
-            // self.state_store
-            //     .put_new_session(session_id)
-            //     .await
-            //     .context(ex_error::StateStoreSnafu)?;
+            #[cfg(feature = "state-store-persist-session-oncreate")]
+            self.state_store
+                .put_new_session(session_id)
+                .await
+                .context(ex_error::StateStoreSnafu)?;
 
             // Record the result as part of the current span.
             tracing::Span::current().record("new_sessions_count", sessions.len());

--- a/crates/executor/src/tests/statestore_queries_unittest.rs
+++ b/crates/executor/src/tests/statestore_queries_unittest.rs
@@ -1,5 +1,8 @@
+use crate::QueryResult;
+use crate::error::Result;
 use crate::models::QueryContext;
 use crate::service::{CoreExecutionService, ExecutionService};
+use crate::session::UserSession;
 use crate::utils::Config;
 use catalog_metastore::InMemoryMetastore;
 use catalog_metastore::metastore_bootstrap_config::MetastoreBootstrapConfig;
@@ -46,39 +49,73 @@ fn insta_settings(name: &str) -> insta::Settings {
     settings
 }
 
+pub struct Mocker;
+
+impl Mocker {
+    pub fn apply_bypass_queries_mock(state_store_mock: &mut MockStateStore, count: usize) {
+        state_store_mock
+            .expect_put_query()
+            .times(count)
+            .returning(|_| Ok(()));
+        state_store_mock
+            .expect_update_query()
+            .times(count)
+            .returning(|_| Ok(()));
+    }
+
+    pub fn apply_bypass_put_queries_only_mock(state_store_mock: &mut MockStateStore, count: usize) {
+        state_store_mock
+            .expect_put_query()
+            .times(count)
+            .returning(|_| Ok(()));
+    }
+
+    pub fn apply_create_session_mock(
+        state_store_mock: &mut MockStateStore,
+        f: fn(&str) -> state_store::Result<SessionRecord>,
+    ) {
+        state_store_mock
+            .expect_put_new_session()
+            .returning(|_| Ok(()));
+        state_store_mock.expect_put_session().returning(|_| Ok(()));
+        state_store_mock.expect_get_session().returning(f);
+    }
+
+    pub async fn create_session(
+        executor: Arc<dyn ExecutionService>,
+        session_id: &str,
+    ) -> Result<Arc<UserSession>> {
+        timeout(
+            MOCK_RELATED_TIMEOUT_DURATION,
+            executor.create_session(session_id),
+        )
+        .await
+        .expect("Create session timed out")
+    }
+
+    pub async fn query(
+        executor: Arc<dyn ExecutionService>,
+        session_id: &str,
+        query_context: QueryContext,
+        sql: &str,
+    ) -> Result<QueryResult> {
+        timeout(
+            MOCK_RELATED_TIMEOUT_DURATION,
+            executor.query(session_id, sql, query_context.clone()),
+        )
+        .await
+        .expect("Query timed out")
+    }
+}
+
 #[allow(clippy::expect_used)]
 #[tokio::test]
 async fn test_query_lifecycle_ok_query() {
-    let query_context = QueryContext::new(
-        Some("test_database".to_string()),
-        Some("test_schema".to_string()),
-        None,
-    )
-    .with_request_id(Uuid::default());
-
     let mut state_store_mock = MockStateStore::new();
-    state_store_mock
-        .expect_get_session()
-        .returning(|_| {
-            let mut session = SessionRecord::new(TEST_SESSION_ID);
-            session.variables.insert("database".to_string(), state_store::Variable {
-                name: "database".to_string(),
-                value: "embucket".to_string(),
-                value_type: "text".to_string(),
-                comment: None,
-                created_at: 1,
-                updated_at: None,
-            });
-            session.variables.insert("schema".to_string(), state_store::Variable {
-                name: "schema".to_string(),
-                value: "public".to_string(),
-                value_type: "text".to_string(),
-                comment: None,
-                created_at: 1,
-                updated_at: None,
-            });
-            Ok(session)
-        });
+    Mocker::apply_create_session_mock(&mut state_store_mock, |_| {
+        Ok(SessionRecord::new(TEST_SESSION_ID))
+    });
+    Mocker::apply_bypass_queries_mock(&mut state_store_mock, 2);
 
     state_store_mock
         .expect_put_query()
@@ -106,6 +143,7 @@ async fn test_query_lifecycle_ok_query() {
             });
             true
         });
+
     state_store_mock
         .expect_update_query()
         .times(1)
@@ -118,8 +156,8 @@ async fn test_query_lifecycle_ok_query() {
                   "request_id": "00000000-0000-0000-0000-000000000000",
                   "query_text": "SELECT 1 AS a, 2.0 AS b, '3' AS 'c'",
                   "session_id": "test_session_id",
-                  "database_name": "test_database",
-                  "schema_name": "test_schema",
+                  "database_name": "embucket",
+                  "schema_name": "public",
                   "query_type": "SELECT",
                   "warehouse_type": "DEFAULT",
                   "execution_status": "Success",
@@ -139,72 +177,71 @@ async fn test_query_lifecycle_ok_query() {
             true
         });
 
-    let state_store: Arc<dyn StateStore> = Arc::new(state_store_mock);
+    let ctx = QueryContext::new(
+        Some("test_database".to_string()),
+        Some("test_schema".to_string()),
+        None,
+    )
+    .with_request_id(Uuid::default());
 
     let metastore = Arc::new(InMemoryMetastore::new());
     MetastoreBootstrapConfig::bootstrap()
         .apply(metastore.clone())
         .await
-        .expect("Failed to bootstrap metastore");    
-    let execution_svc = CoreExecutionService::new_test_executor(
-        metastore,
-        state_store,
-        Arc::new(Config::default()),
-    )
-    .await
-    .expect("Failed to create execution service");
+        .expect("Failed to bootstrap metastore");
 
-    timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.create_session(TEST_SESSION_ID),
-    )
-    .await
-    .expect("Create session timed out")
-    .expect("Failed to create session");  
+    let ex: Arc<dyn ExecutionService> = Arc::new(
+        CoreExecutionService::new_test_executor(
+            metastore,
+            Arc::new(state_store_mock),
+            Arc::new(Config::default()),
+        )
+        .await
+        .expect("Failed to create execution service"),
+    );
 
-    // See note about timeout above
-    let _ = timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.query(
-            TEST_SESSION_ID,
-            "SELECT 1 AS a, 2.0 AS b, '3' AS 'c'",
-            query_context,
-        ),
+    Mocker::create_session(ex.clone(), TEST_SESSION_ID)
+        .await
+        .expect("Failed to create session");
+
+    Mocker::query(
+        ex.clone(),
+        TEST_SESSION_ID,
+        ctx.clone(),
+        "SET DATABASE = 'embucket'",
     )
     .await
-    .expect("Query timed out")
+    .expect("Query execution failed");
+
+    Mocker::query(
+        ex.clone(),
+        TEST_SESSION_ID,
+        ctx.clone(),
+        "SET SCHEMA = 'public'",
+    )
+    .await
+    .expect("Query execution failed");
+
+    Mocker::query(
+        ex.clone(),
+        TEST_SESSION_ID,
+        ctx.clone(),
+        "SELECT 1 AS a, 2.0 AS b, '3' AS 'c'",
+    )
+    .await
     .expect("Query execution failed");
 }
 
 #[allow(clippy::expect_used)]
 #[tokio::test]
 async fn test_query_lifecycle_ok_insert() {
-    let query_context = QueryContext::new(
-        Some(TEST_DATABASE.to_string()),
-        Some(TEST_SCHEMA.to_string()),
-        None,
-    )
-    .with_query_submission_time(Some(TEST_TIMESTAMP))
-    .with_request_id(Uuid::default());
-
     let mut state_store_mock = MockStateStore::new();
-    state_store_mock
-        .expect_put_new_session()
-        .returning(|_| Ok(()));
-    state_store_mock
-        .expect_get_session()
-        .returning(|_| Ok(SessionRecord::new(TEST_SESSION_ID)));
-    state_store_mock
-        .expect_put_query()
-        .times(2)
-        .returning(|_| Ok(()));
+    Mocker::apply_create_session_mock(&mut state_store_mock, |_| {
+        Ok(SessionRecord::new(TEST_SESSION_ID))
+    });
+    Mocker::apply_bypass_queries_mock(&mut state_store_mock, 1);
+    Mocker::apply_bypass_put_queries_only_mock(&mut state_store_mock, 1);
 
-    // bypass 1st update
-    state_store_mock
-        .expect_update_query()
-        .times(1)
-        .returning(|_| Ok(()));
-    // verify 2nd update
     state_store_mock
         .expect_update_query()
         .times(1)
@@ -239,79 +276,63 @@ async fn test_query_lifecycle_ok_insert() {
             true
         });
 
-    let state_store: Arc<dyn StateStore> = Arc::new(state_store_mock);
-
     let metastore = Arc::new(InMemoryMetastore::new());
     MetastoreBootstrapConfig::bootstrap()
         .apply(metastore.clone())
         .await
         .expect("Failed to bootstrap metastore");
 
-    let execution_svc = CoreExecutionService::new_test_executor(
-        metastore,
-        state_store,
-        Arc::new(Config::default()),
-    )
-    .await
-    .expect("Failed to create execution service");
+    let ex: Arc<dyn ExecutionService> = Arc::new(
+        CoreExecutionService::new_test_executor(
+            metastore,
+            Arc::new(state_store_mock),
+            Arc::new(Config::default()),
+        )
+        .await
+        .expect("Failed to create execution service"),
+    );
 
-    timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.create_session(TEST_SESSION_ID),
+    let ctx = QueryContext::new(
+        Some(TEST_DATABASE.to_string()),
+        Some(TEST_SCHEMA.to_string()),
+        None,
     )
-    .await
-    .expect("Create session timed out")
-    .expect("Failed to create session");
+    .with_query_submission_time(Some(TEST_TIMESTAMP))
+    .with_request_id(Uuid::default());
 
-    // prepare table
-    let _ = timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.query(
-            TEST_SESSION_ID,
-            "create table if not exists embucket.public.table (id int)",
-            query_context.clone(),
-        ),
+    Mocker::create_session(ex.clone(), TEST_SESSION_ID)
+        .await
+        .expect("Failed to create session");
+
+    Mocker::query(
+        ex.clone(),
+        TEST_SESSION_ID,
+        ctx.clone(),
+        "create table if not exists embucket.public.table (id int)",
     )
     .await
-    .expect("Query timed out")
     .expect("Query execution failed");
 
-    // insert
-    timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.query(
-            TEST_SESSION_ID,
-            "INSERT INTO embucket.public.table VALUES (1)",
-            query_context,
-        ),
+    Mocker::query(
+        ex.clone(),
+        TEST_SESSION_ID,
+        ctx.clone(),
+        "INSERT INTO embucket.public.table VALUES (1)",
     )
     .await
-    .expect("Query timed out")
     .expect("Query execution failed");
 }
 
 #[allow(clippy::expect_used)]
 #[tokio::test]
 async fn test_query_lifecycle_ok_update() {
-    let query_context = QueryContext::default().with_request_id(Uuid::default());
-
     let mut state_store_mock = MockStateStore::new();
-    state_store_mock
-        .expect_put_new_session()
-        .returning(|_| Ok(()));
-    state_store_mock
-        .expect_get_session()
-        .returning(|_| Ok(SessionRecord::new(TEST_SESSION_ID)));
-    state_store_mock
-        .expect_put_query()
-        .times(2)
-        .returning(|_| Ok(()));
+    Mocker::apply_create_session_mock(&mut state_store_mock, |_| {
+        Ok(SessionRecord::new(TEST_SESSION_ID))
+    });
+    Mocker::apply_bypass_queries_mock(&mut state_store_mock, 1);
+    Mocker::apply_bypass_put_queries_only_mock(&mut state_store_mock, 1);
 
-    // bypass 1st update
-    state_store_mock
-        .expect_update_query()
-        .times(1)
-        .returning(|_| Ok(()));
     // verify 2nd update
     state_store_mock
         .expect_update_query()
@@ -343,7 +364,7 @@ async fn test_query_lifecycle_ok_update() {
             true
         });
 
-    let state_store: Arc<dyn StateStore> = Arc::new(state_store_mock);
+    let ctx = QueryContext::default().with_request_id(Uuid::default());
 
     let metastore = Arc::new(InMemoryMetastore::new());
     MetastoreBootstrapConfig::bootstrap()
@@ -351,29 +372,25 @@ async fn test_query_lifecycle_ok_update() {
         .await
         .expect("Failed to bootstrap metastore");
 
-    let execution_svc = CoreExecutionService::new_test_executor(
-        metastore,
-        state_store,
-        Arc::new(Config::default()),
-    )
-    .await
-    .expect("Failed to create execution service");
+    let ex: Arc<dyn ExecutionService> = Arc::new(
+        CoreExecutionService::new_test_executor(
+            metastore,
+            Arc::new(state_store_mock),
+            Arc::new(Config::default()),
+        )
+        .await
+        .expect("Failed to create execution service"),
+    );
 
-    timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.create_session(TEST_SESSION_ID),
-    )
-    .await
-    .expect("Create session timed out")
-    .expect("Failed to create session");
+    Mocker::create_session(ex.clone(), TEST_SESSION_ID)
+        .await
+        .expect("Failed to create session");
 
-    // prepare table
-    let _ = timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.query(
-            TEST_SESSION_ID,
-            "
-        CREATE TABLE embucket.public.table AS SELECT 
+    Mocker::query(
+        ex.clone(),
+        TEST_SESSION_ID,
+        ctx.clone(),
+        "CREATE TABLE embucket.public.table AS SELECT 
             id, 
             name, 
             RANDOM() AS random_value, 
@@ -384,50 +401,30 @@ async fn test_query_lifecycle_ok_update() {
             (3, 'Charlie'),
             (4, 'David')
         ) AS t(id, name);",
-            query_context.clone(),
-        ),
     )
     .await
-    .expect("Query timed out")
     .expect("Query execution failed");
 
-    // update
-    timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.query(
-            TEST_SESSION_ID,
-            "UPDATE embucket.public.table SET name = 'John'",
-            query_context,
-        ),
+    Mocker::query(
+        ex.clone(),
+        TEST_SESSION_ID,
+        ctx.clone(),
+        "UPDATE embucket.public.table SET name = 'John'",
     )
     .await
-    .expect("Query timed out")
     .expect("Query execution failed");
 }
 
 #[allow(clippy::expect_used)]
 #[tokio::test]
 async fn test_query_lifecycle_delete_failed() {
-    let query_context = QueryContext::default().with_request_id(Uuid::default());
-
     let mut state_store_mock = MockStateStore::new();
-    state_store_mock
-        .expect_put_new_session()
-        .returning(|_| Ok(()));
-    state_store_mock
-        .expect_get_session()
-        .returning(|_| Ok(SessionRecord::new(TEST_SESSION_ID)));
-    state_store_mock
-        .expect_put_query()
-        .times(2)
-        .returning(|_| Ok(()));
+    Mocker::apply_create_session_mock(&mut state_store_mock, |_| {
+        Ok(SessionRecord::new(TEST_SESSION_ID))
+    });
+    Mocker::apply_bypass_queries_mock(&mut state_store_mock, 1);
+    Mocker::apply_bypass_put_queries_only_mock(&mut state_store_mock, 1);
 
-    // bypass 1st update
-    state_store_mock
-        .expect_update_query()
-        .times(1)
-        .returning(|_| Ok(()));
-    // verify 2nd update
     state_store_mock
         .expect_update_query()
         .times(1)
@@ -459,7 +456,7 @@ async fn test_query_lifecycle_delete_failed() {
             true
         });
 
-    let state_store: Arc<dyn StateStore> = Arc::new(state_store_mock);
+    let ctx = QueryContext::default().with_request_id(Uuid::default());
 
     let metastore = Arc::new(InMemoryMetastore::new());
     MetastoreBootstrapConfig::bootstrap()
@@ -467,29 +464,25 @@ async fn test_query_lifecycle_delete_failed() {
         .await
         .expect("Failed to bootstrap metastore");
 
-    let execution_svc = CoreExecutionService::new_test_executor(
-        metastore,
-        state_store,
-        Arc::new(Config::default()),
-    )
-    .await
-    .expect("Failed to create execution service");
+    let ex: Arc<dyn ExecutionService> = Arc::new(
+        CoreExecutionService::new_test_executor(
+            metastore,
+            Arc::new(state_store_mock),
+            Arc::new(Config::default()),
+        )
+        .await
+        .expect("Failed to create execution service"),
+    );
 
-    timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.create_session(TEST_SESSION_ID),
-    )
-    .await
-    .expect("Create session timed out")
-    .expect("Failed to create session");
+    Mocker::create_session(ex.clone(), TEST_SESSION_ID)
+        .await
+        .expect("Failed to create session");
 
-    // prepare table
-    let _ = timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.query(
-            TEST_SESSION_ID,
-            "
-        CREATE TABLE embucket.public.table AS SELECT 
+    Mocker::query(
+        ex.clone(),
+        TEST_SESSION_ID,
+        ctx.clone(),
+        "CREATE TABLE embucket.public.table AS SELECT 
             id, 
             name, 
             RANDOM() AS random_value, 
@@ -500,50 +493,30 @@ async fn test_query_lifecycle_delete_failed() {
             (3, 'Charlie'),
             (4, 'David')
         ) AS t(id, name);",
-            query_context.clone(),
-        ),
     )
     .await
-    .expect("Query timed out")
     .expect("Query execution failed");
 
-    // update
-    let _ = timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.query(
-            TEST_SESSION_ID,
-            "DELETE FROM embucket.public.table",
-            query_context,
-        ),
+    Mocker::query(
+        ex.clone(),
+        TEST_SESSION_ID,
+        ctx.clone(),
+        "DELETE FROM embucket.public.table",
     )
     .await
-    .expect("Query timed out")
     .expect_err("Query expected to fail");
 }
 
 #[allow(clippy::expect_used)]
 #[tokio::test]
 async fn test_query_lifecycle_ok_truncate() {
-    let query_context = QueryContext::default().with_request_id(Uuid::default());
-
     let mut state_store_mock = MockStateStore::new();
-    state_store_mock
-        .expect_put_new_session()
-        .returning(|_| Ok(()));
-    state_store_mock
-        .expect_get_session()
-        .returning(|_| Ok(SessionRecord::new(TEST_SESSION_ID)));
-    state_store_mock
-        .expect_put_query()
-        .times(2)
-        .returning(|_| Ok(()));
+    Mocker::apply_create_session_mock(&mut state_store_mock, |_| {
+        Ok(SessionRecord::new(TEST_SESSION_ID))
+    });
+    Mocker::apply_bypass_queries_mock(&mut state_store_mock, 1);
+    Mocker::apply_bypass_put_queries_only_mock(&mut state_store_mock, 1);
 
-    // bypass 1st update
-    state_store_mock
-        .expect_update_query()
-        .times(1)
-        .returning(|_| Ok(()));
-    // verify 2nd update
     state_store_mock
         .expect_update_query()
         .times(1)
@@ -575,7 +548,7 @@ async fn test_query_lifecycle_ok_truncate() {
             true
         });
 
-    let state_store: Arc<dyn StateStore> = Arc::new(state_store_mock);
+    let ctx = QueryContext::default().with_request_id(Uuid::default());
 
     let metastore = Arc::new(InMemoryMetastore::new());
     MetastoreBootstrapConfig::bootstrap()
@@ -583,29 +556,25 @@ async fn test_query_lifecycle_ok_truncate() {
         .await
         .expect("Failed to bootstrap metastore");
 
-    let execution_svc = CoreExecutionService::new_test_executor(
-        metastore,
-        state_store,
-        Arc::new(Config::default()),
-    )
-    .await
-    .expect("Failed to create execution service");
+    let ex: Arc<dyn ExecutionService> = Arc::new(
+        CoreExecutionService::new_test_executor(
+            metastore,
+            Arc::new(state_store_mock),
+            Arc::new(Config::default()),
+        )
+        .await
+        .expect("Failed to create execution service"),
+    );
 
-    timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.create_session(TEST_SESSION_ID),
-    )
-    .await
-    .expect("Create session timed out")
-    .expect("Failed to create session");
+    Mocker::create_session(ex.clone(), TEST_SESSION_ID)
+        .await
+        .expect("Failed to create session");
 
-    // prepare table
-    let _ = timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.query(
-            TEST_SESSION_ID,
-            "
-        CREATE TABLE embucket.public.table AS SELECT 
+    Mocker::query(
+        ex.clone(),
+        TEST_SESSION_ID,
+        ctx.clone(),
+        "CREATE TABLE embucket.public.table AS SELECT 
             id, 
             name, 
             RANDOM() AS random_value, 
@@ -616,49 +585,30 @@ async fn test_query_lifecycle_ok_truncate() {
             (3, 'Charlie'),
             (4, 'David')
         ) AS t(id, name);",
-            query_context.clone(),
-        ),
     )
     .await
-    .expect("Query timed out")
     .expect("Query execution failed");
 
-    // update
-    let _ = timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.query(
-            TEST_SESSION_ID,
-            "TRUNCATE TABLE embucket.public.table",
-            query_context,
-        ),
+    Mocker::query(
+        ex.clone(),
+        TEST_SESSION_ID,
+        ctx.clone(),
+        "TRUNCATE TABLE embucket.public.table",
     )
     .await
-    .expect("Query timed out")
     .expect("Query execution failed");
 }
 
 #[allow(clippy::expect_used)]
 #[tokio::test]
 async fn test_query_lifecycle_ok_merge() {
-    let query_context = QueryContext::default().with_request_id(Uuid::default());
-
     let mut state_store_mock = MockStateStore::new();
-    state_store_mock
-        .expect_put_new_session()
-        .returning(|_| Ok(()));
-    state_store_mock
-        .expect_get_session()
-        .returning(|_| Ok(SessionRecord::new(TEST_SESSION_ID)));
-    state_store_mock
-        .expect_put_query()
-        .times(3)
-        .returning(|_| Ok(()));
+    Mocker::apply_create_session_mock(&mut state_store_mock, |_| {
+        Ok(SessionRecord::new(TEST_SESSION_ID))
+    });
+    Mocker::apply_bypass_queries_mock(&mut state_store_mock, 2);
+    Mocker::apply_bypass_put_queries_only_mock(&mut state_store_mock, 1);
 
-    // bypass first two updates
-    state_store_mock
-        .expect_update_query()
-        .times(2)
-        .returning(|_| Ok(()));
     // verify 3rd update
     state_store_mock
         .expect_update_query()
@@ -670,7 +620,7 @@ async fn test_query_lifecycle_ok_merge() {
                 {
                   "query_id": "00000000-0000-0000-0000-000000000000",
                   "request_id": "00000000-0000-0000-0000-000000000000",
-                  "query_text": "MERGE INTO t1 USING (SELECT * FROM t2) AS t2 ON t1.a = t2.a WHEN MATCHED THEN UPDATE SET t1.c = t2.c WHEN NOT MATCHED THEN INSERT (a,c) VALUES(t2.a,t2.c)",
+                  "query_text": "MERGE INTO t1 USING \n        (SELECT * FROM t2) AS t2 \n        ON t1.a = t2.a \n        WHEN MATCHED THEN UPDATE SET t1.c = t2.c \n        WHEN NOT MATCHED THEN INSERT (a,c) VALUES(t2.a,t2.c)",
                   "session_id": "test_session_id",
                   "database_name": "embucket",
                   "schema_name": "public",
@@ -683,7 +633,7 @@ async fn test_query_lifecycle_ok_merge() {
                   "rows_inserted": 1,
                   "execution_time": "1",
                   "release_version": "test-version",
-                  "query_hash": "16532873076018472935",
+                  "query_hash": "10180476120311618623",
                   "query_hash_version": 1,
                   "query_metrics": "[query_metrics]"
                 }
@@ -692,7 +642,7 @@ async fn test_query_lifecycle_ok_merge() {
             true
         });
 
-    let state_store: Arc<dyn StateStore> = Arc::new(state_store_mock);
+    let ctx = QueryContext::default().with_request_id(Uuid::default());
 
     let metastore = Arc::new(InMemoryMetastore::new());
     MetastoreBootstrapConfig::bootstrap()
@@ -700,29 +650,25 @@ async fn test_query_lifecycle_ok_merge() {
         .await
         .expect("Failed to bootstrap metastore");
 
-    let execution_svc = CoreExecutionService::new_test_executor(
-        metastore,
-        state_store,
-        Arc::new(Config::default()),
-    )
-    .await
-    .expect("Failed to create execution service");
+    let ex: Arc<dyn ExecutionService> = Arc::new(
+        CoreExecutionService::new_test_executor(
+            metastore,
+            Arc::new(state_store_mock),
+            Arc::new(Config::default()),
+        )
+        .await
+        .expect("Failed to create execution service"),
+    );
 
-    timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.create_session(TEST_SESSION_ID),
-    )
-    .await
-    .expect("Create session timed out")
-    .expect("Failed to create session");
+    Mocker::create_session(ex.clone(), TEST_SESSION_ID)
+        .await
+        .expect("Failed to create session");
 
-    // prepare tables
-    let _ = timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.query(
-            TEST_SESSION_ID,
-            "
-        CREATE TABLE embucket.public.t1 AS SELECT 
+    Mocker::query(
+        ex.clone(),
+        TEST_SESSION_ID,
+        ctx.clone(),
+        "CREATE TABLE embucket.public.t1 AS SELECT 
         a,b,c
         FROM (VALUES 
             (1,'b1','c1'),
@@ -730,19 +676,15 @@ async fn test_query_lifecycle_ok_merge() {
             (2,'b3','c3'),
             (3,'b4','c4')
         ) AS t(a, b, c);",
-            query_context.clone(),
-        ),
     )
     .await
-    .expect("Query timed out")
     .expect("Query execution failed");
 
-    let _ = timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.query(
-            TEST_SESSION_ID,
-            "
-        CREATE TABLE embucket.public.t2 AS SELECT
+    Mocker::query(
+        ex.clone(),
+        TEST_SESSION_ID,
+        ctx.clone(),
+        "CREATE TABLE embucket.public.t2 AS SELECT
         a,b,c
         FROM (VALUES 
             (1,'b_5','c_5'),
@@ -750,39 +692,32 @@ async fn test_query_lifecycle_ok_merge() {
             (2,'b_7','c_7'),
             (4,'b_8','c_8')
         ) AS t(a, b, c);",
-            query_context.clone(),
-        ),
     )
     .await
-    .expect("Query timed out")
     .expect("Query execution failed");
 
-    let _ = timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.query(TEST_SESSION_ID, "MERGE INTO t1 USING (SELECT * FROM t2) AS t2 ON t1.a = t2.a WHEN MATCHED THEN UPDATE SET t1.c = t2.c WHEN NOT MATCHED THEN INSERT (a,c) VALUES(t2.a,t2.c)", query_context),
+    Mocker::query(
+        ex.clone(),
+        TEST_SESSION_ID,
+        ctx.clone(),
+        "MERGE INTO t1 USING 
+        (SELECT * FROM t2) AS t2 
+        ON t1.a = t2.a 
+        WHEN MATCHED THEN UPDATE SET t1.c = t2.c 
+        WHEN NOT MATCHED THEN INSERT (a,c) VALUES(t2.a,t2.c)",
     )
     .await
-    .expect("Query timed out")
     .expect("Query execution failed");
 }
 
 #[allow(clippy::expect_used)]
 #[tokio::test]
 async fn test_query_lifecycle_query_status_incident_limit_exceeded() {
-    let query_context = QueryContext::new(
-        Some(TEST_DATABASE.to_string()),
-        Some(TEST_SCHEMA.to_string()),
-        None,
-    )
-    .with_request_id(Uuid::default());
-
     let mut state_store_mock = MockStateStore::new();
-    state_store_mock
-        .expect_put_new_session()
-        .returning(|_| Ok(()));
-    state_store_mock
-        .expect_get_session()
-        .returning(|_| Ok(SessionRecord::new(TEST_SESSION_ID)));
+    Mocker::apply_create_session_mock(&mut state_store_mock, |_| {
+        Ok(SessionRecord::new(TEST_SESSION_ID))
+    });
+
     state_store_mock.expect_put_query()
         .returning(|_| Ok(()) )
         .times(1)
@@ -813,42 +748,46 @@ async fn test_query_lifecycle_query_status_incident_limit_exceeded() {
             true
         });
 
-    let state_store: Arc<dyn StateStore> = Arc::new(state_store_mock);
+    let ctx = QueryContext::new(
+        Some(TEST_DATABASE.to_string()),
+        Some(TEST_SCHEMA.to_string()),
+        None,
+    )
+    .with_request_id(Uuid::default());
 
     let metastore = Arc::new(InMemoryMetastore::new());
-    let execution_svc = CoreExecutionService::new_test_executor(
-        metastore,
-        state_store,
-        Arc::new(Config::default().with_max_concurrency_level(0)),
-    )
-    .await
-    .expect("Failed to create execution service");
+    MetastoreBootstrapConfig::bootstrap()
+        .apply(metastore.clone())
+        .await
+        .expect("Failed to bootstrap metastore");
 
-    execution_svc
-        .create_session(TEST_SESSION_ID)
+    let ex: Arc<dyn ExecutionService> = Arc::new(
+        CoreExecutionService::new_test_executor(
+            metastore,
+            Arc::new(state_store_mock),
+            Arc::new(Config::default().with_max_concurrency_level(0)),
+        )
+        .await
+        .expect("Failed to create execution service"),
+    );
+
+    Mocker::create_session(ex.clone(), TEST_SESSION_ID)
         .await
         .expect("Failed to create session");
 
-    // See note about timeout above
-    let _ = timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.query(TEST_SESSION_ID, "SELECT 1", query_context),
-    )
-    .await
-    .expect("Query timed out")
-    .expect_err("Query execution should fail");
+    Mocker::query(ex.clone(), TEST_SESSION_ID, ctx.clone(), "SELECT 1")
+        .await
+        .expect_err("Query execution should fail");
 }
 
 #[allow(clippy::expect_used)]
 #[tokio::test]
 async fn test_query_lifecycle_query_status_fail() {
     let mut state_store_mock = MockStateStore::new();
-    state_store_mock
-        .expect_put_new_session()
-        .returning(|_| Ok(()));
-    state_store_mock
-        .expect_get_session()
-        .returning(|_| Ok(SessionRecord::new(TEST_SESSION_ID)));
+    Mocker::apply_create_session_mock(&mut state_store_mock, |_| {
+        Ok(SessionRecord::new(TEST_SESSION_ID))
+    });
+
     state_store_mock
         .expect_put_query()
         .times(1)
@@ -902,36 +841,35 @@ async fn test_query_lifecycle_query_status_fail() {
             true
         });
 
-    let state_store: Arc<dyn StateStore> = Arc::new(state_store_mock);
+    let ctx = QueryContext::default().with_request_id(Uuid::new_v4());
 
     let metastore = Arc::new(InMemoryMetastore::new());
-    let execution_svc = CoreExecutionService::new_test_executor(
-        metastore,
-        state_store,
-        Arc::new(Config::default()),
-    )
-    .await
-    .expect("Failed to create execution service");
+    MetastoreBootstrapConfig::bootstrap()
+        .apply(metastore.clone())
+        .await
+        .expect("Failed to bootstrap metastore");
 
-    timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.create_session(TEST_SESSION_ID),
-    )
-    .await
-    .expect("Create session timed out")
-    .expect("Failed to create session");
+    let ex: Arc<dyn ExecutionService> = Arc::new(
+        CoreExecutionService::new_test_executor(
+            metastore,
+            Arc::new(state_store_mock),
+            Arc::new(Config::default()),
+        )
+        .await
+        .expect("Failed to create execution service"),
+    );
 
-    // See note about timeout above
-    let _ = timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.query(
-            TEST_SESSION_ID,
-            "SELECT should fail",
-            QueryContext::default().with_request_id(Uuid::new_v4()),
-        ),
+    Mocker::create_session(ex.clone(), TEST_SESSION_ID)
+        .await
+        .expect("Failed to create session");
+
+    Mocker::query(
+        ex.clone(),
+        TEST_SESSION_ID,
+        ctx.clone(),
+        "SELECT should fail",
     )
     .await
-    .expect("Query timed out")
     .expect_err("Query execution should fail");
 }
 
@@ -939,12 +877,10 @@ async fn test_query_lifecycle_query_status_fail() {
 #[tokio::test]
 async fn test_query_lifecycle_query_status_cancelled() {
     let mut state_store_mock = MockStateStore::new();
-    state_store_mock
-        .expect_put_new_session()
-        .returning(|_| Ok(()));
-    state_store_mock
-        .expect_get_session()
-        .returning(|_| Ok(SessionRecord::new(TEST_SESSION_ID)));
+    Mocker::apply_create_session_mock(&mut state_store_mock, |_| {
+        Ok(SessionRecord::new(TEST_SESSION_ID))
+    });
+
     state_store_mock
         .expect_put_query()
         .times(1)
@@ -997,43 +933,39 @@ async fn test_query_lifecycle_query_status_cancelled() {
             true
         });
 
-    let state_store: Arc<dyn StateStore> = Arc::new(state_store_mock);
+    let ctx = QueryContext::default().with_request_id(Uuid::default());
 
     let metastore = Arc::new(InMemoryMetastore::new());
-    let execution_svc = CoreExecutionService::new_test_executor(
-        metastore,
-        state_store,
-        Arc::new(Config::default()),
-    )
-    .await
-    .expect("Failed to create execution service");
+    MetastoreBootstrapConfig::bootstrap()
+        .apply(metastore.clone())
+        .await
+        .expect("Failed to bootstrap metastore");
 
-    timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.create_session(TEST_SESSION_ID),
-    )
-    .await
-    .expect("Create session timed out")
-    .expect("Failed to create session");
+    let ex: Arc<dyn ExecutionService> = Arc::new(
+        CoreExecutionService::new_test_executor(
+            metastore,
+            Arc::new(state_store_mock),
+            Arc::new(Config::default()),
+        )
+        .await
+        .expect("Failed to create execution service"),
+    );
+
+    Mocker::create_session(ex.clone(), TEST_SESSION_ID)
+        .await
+        .expect("Failed to create session");
 
     // See note about timeout above
     let query_handle = timeout(
         MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.submit(
-            TEST_SESSION_ID,
-            "SELECT 1",
-            QueryContext::default().with_request_id(Uuid::new_v4()),
-        ),
+        ex.submit(TEST_SESSION_ID, "SELECT 1", ctx),
     )
     .await
     .expect("Query timed out")
     .expect("Query submit error");
 
-    let _ = timeout(
-        MOCK_RELATED_TIMEOUT_DURATION,
-        execution_svc.abort(query_handle),
-    )
-    .await
-    .expect("Query timed out")
-    .expect("Failed to cancel query");
+    let _ = timeout(MOCK_RELATED_TIMEOUT_DURATION, ex.abort(query_handle))
+        .await
+        .expect("Query timed out")
+        .expect("Failed to cancel query");
 }

--- a/crates/executor/src/tests/statestore_queries_unittest.rs
+++ b/crates/executor/src/tests/statestore_queries_unittest.rs
@@ -46,6 +46,10 @@ fn insta_settings(name: &str) -> insta::Settings {
         r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z",
         "2026-01-01T01:01:01.000001Z",
     );
+    settings.add_filter(
+        r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z",
+        "2026-01-01T01:01:01.001Z",
+    );
     settings
 }
 
@@ -373,7 +377,7 @@ async fn test_query_lifecycle_ok_insert() {
                   "user_database_name": "test_database",
                   "user_schema_name": "test_schema",
                   "query_metrics": "[query_metrics]",
-                  "query_submission_time": 1764161275445
+                  "query_submission_time": "2026-01-01T01:01:01.001Z"
                 }
                 "#);
             });

--- a/crates/state-store/src/models.rs
+++ b/crates/state-store/src/models.rs
@@ -289,7 +289,7 @@ pub struct Query {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub client_app_version: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub query_submission_time: Option<u64>,
+    pub query_submission_time: Option<DateTime<Utc>>,
 }
 
 impl Query {
@@ -389,8 +389,11 @@ impl Query {
         self.client_app_version = Some(client_app_version);
     }
 
+    #[allow(clippy::cast_possible_wrap, clippy::as_conversions)]
     pub const fn set_query_submission_time(&mut self, query_submission_time: u64) {
-        self.query_submission_time = Some(query_submission_time);
+        // Convert u64 timestamp to DateTime<Utc>
+        let dt = DateTime::<Utc>::from_timestamp_millis(query_submission_time as i64);
+        self.query_submission_time = dt;
     }
 
     #[allow(clippy::as_conversions, clippy::cast_sign_loss)]

--- a/crates/state-store/src/models.rs
+++ b/crates/state-store/src/models.rs
@@ -284,6 +284,12 @@ pub struct Query {
     pub query_history_time: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub query_result_time: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_app_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_app_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub query_submission_time: Option<u64>,
 }
 
 impl Query {
@@ -317,6 +323,18 @@ impl Query {
 
     pub fn set_schema_name(&mut self, schema: String) {
         self.schema_name = Some(schema);
+    }
+
+    pub fn set_user_name(&mut self, user: String) {
+        self.user_name = Some(user);
+    }
+
+    pub fn set_user_database(&mut self, database: String) {
+        self.user_database_name = Some(database);
+    }
+
+    pub fn set_user_schema(&mut self, schema: String) {
+        self.user_schema_name = Some(schema);
     }
 
     pub const fn set_execution_status(&mut self, status: ExecutionStatus) {
@@ -361,6 +379,18 @@ impl Query {
 
     pub fn set_query_type(&mut self, query_type: String) {
         self.query_type = Some(query_type);
+    }
+
+    pub fn set_client_app_id(&mut self, client_app_id: String) {
+        self.client_app_id = Some(client_app_id);
+    }
+
+    pub fn set_client_app_version(&mut self, client_app_version: String) {
+        self.client_app_version = Some(client_app_version);
+    }
+
+    pub const fn set_query_submission_time(&mut self, query_submission_time: u64) {
+        self.query_submission_time = Some(query_submission_time);
     }
 
     #[allow(clippy::as_conversions, clippy::cast_sign_loss)]


### PR DESCRIPTION
## Save Query Attrs
* query_submission_time
* user_database_name (user context)
* user_schema_name (user context)
* database_name / schema_name (effective context) returned by `current_database` / `current_schema`
* client_app_id / client_app_version
* query_type - added explain/analyze

### Features
In this PR - by default embucket/lambda won't persist SessionRecord when session created. Though Session updates will be persisted.
`state-store-persist-session-oncreate` when enabled - it allows saving empty session (having just session_id)

### User Context behaviour changed
Previously, the context received in the login request was persisted in the state store.
Now, context such as UserName, Warehouse, Database, Schema, AccountName, ClientAppId, and ClientAppVersion is encoded directly in the authentication token.
This approach improves query latency because the query request can be sent immediately after the login request (~20 ms vs. >200 ms).
It also makes the Lambda cheaper when invoked from SnowSQL, which by default issues a login request for every query. As a result, we have fewer state-store reads and writes.

### Changed behaviour: current_database / current_schema
```
    pub fn current_schema(&self) -> String {
        - self.query_context
        -    .schema
        -    .clone()
        -    .or_else(|| self.session.get_session_variable("schema"))
        self.session
       +     .get_session_variable("schema")
       +     .or_else(|| self.query_context.schema.clone())
       +     .unwrap_or_else(|| "public".to_string())
```

### Unittests updated & refactored
