### PR TITLE
ci: append docker pull instructions to release notes

### DIFF
--- a/.github/workflows/build-and-release.yml.yml
+++ b/.github/workflows/build-and-release.yml.yml
@@ -92,6 +92,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-docker
+    permissions:
+      contents: write
     steps:
       - name: Download digests
         uses: actions/download-artifact@v6
@@ -130,3 +132,27 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+
+      - name: Append Docker pull instructions to release notes
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+          REGISTRY_IMAGE: ${{ env.REGISTRY_IMAGE }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          body=$(gh release view "$TAG" --json body --jq '.body')
+          if printf '%s' "$body" | grep -q '^## Docker'; then
+            echo "Docker section already present; skipping."
+            exit 0
+          fi
+          {
+            printf '%s\n\n' "$body"
+            printf '## Docker\n\n'
+            printf '```bash\n'
+            printf 'docker pull %s:%s\n' "$REGISTRY_IMAGE" "$version"
+            printf 'docker pull %s:latest\n' "$REGISTRY_IMAGE"
+            printf '```\n'
+          } > "$RUNNER_TEMP/release_body.md"
+          gh release edit "$TAG" --notes-file "$RUNNER_TEMP/release_body.md"


### PR DESCRIPTION
Adds a step to the `build-and-release` workflow that appends a `## Docker` section with `docker pull` commands to the GitHub release body, so the Docker Hub image is discoverable alongside the lambda zips. The step is idempotent — it checks for an existing `## Docker` heading and skips if already present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)