### PR TITLE
fix(merge): partition pruning, EXPLAIN routing, and data-loss fix on the MERGE path

### DIFF
--- a/crates/executor/src/datafusion/logical_analyzer/custom_type_coercion.rs
+++ b/crates/executor/src/datafusion/logical_analyzer/custom_type_coercion.rs
@@ -39,9 +39,22 @@ impl AnalyzerRule for CustomTypeCoercionRewriter {
 }
 
 fn analyze_internal(plan: &LogicalPlan) -> DFResult<Transformed<LogicalPlan>> {
-    // get schema representing all available input fields. This is used for data type
-    // resolution only, so order does not matter here
-    let schema = merge_schema(&plan.inputs());
+    // Get schema representing all available input fields. Used for data-type
+    // resolution only, so order doesn't matter.
+    //
+    // For leaf plan nodes (e.g. `TableScan`), `plan.inputs()` is empty and
+    // `merge_schema` returns an empty schema. If we relied on that, filter
+    // expressions attached to the leaf itself — such as the target filter
+    // that `UserQuery::merge_query` injects via
+    // `LogicalPlanBuilder::scan_with_filters` when the MERGE source is a
+    // partitioned `DataFusionTable` — would see no fields and fail with
+    // "Schema error: No field named …". Fall back to `plan.schema()` in
+    // that case so the rewriter can actually look up the column types.
+    let schema = if plan.inputs().is_empty() {
+        plan.schema().as_ref().clone()
+    } else {
+        merge_schema(&plan.inputs())
+    };
 
     let name_preserver = NamePreserver::new(plan);
     let new_plan = plan.clone().map_expressions(|expr| {

--- a/crates/executor/src/datafusion/physical_plan/merge.rs
+++ b/crates/executor/src/datafusion/physical_plan/merge.rs
@@ -19,6 +19,7 @@ use datafusion_physical_plan::{
     SendableRecordBatchStream,
     coalesce_partitions::CoalescePartitionsExec,
     execution_plan::{Boundedness, EmissionType},
+    metrics::{Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet},
     stream::RecordBatchStreamAdapter,
 };
 use futures::{Stream, StreamExt};
@@ -52,6 +53,11 @@ pub struct MergeIntoCOWSinkExec {
     input: Arc<dyn ExecutionPlan>,
     target: DataFusionTable,
     properties: PlanProperties,
+    /// Per-node metrics surfaced via `EXPLAIN ANALYZE`. Populated with
+    /// `updated_rows` / `inserted_rows` / `deleted_rows` counters after the
+    /// write transaction commits, so `EXPLAIN ANALYZE MERGE INTO …` reports
+    /// how many rows each clause produced alongside the child scan metrics.
+    metrics: ExecutionPlanMetricsSet,
 }
 
 impl MergeIntoCOWSinkExec {
@@ -73,6 +79,7 @@ impl MergeIntoCOWSinkExec {
             input,
             target,
             properties,
+            metrics: ExecutionPlanMetricsSet::new(),
         }
     }
 }
@@ -109,6 +116,13 @@ impl ExecutionPlan for MergeIntoCOWSinkExec {
         vec![&self.input]
     }
 
+    /// Surface per-clause row counts (updated / inserted / deleted) as
+    /// `EXPLAIN ANALYZE` metrics. Values are populated by `execute()` after
+    /// the write transaction commits; they're zero until then.
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
     fn with_new_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
@@ -142,6 +156,16 @@ impl ExecutionPlan for MergeIntoCOWSinkExec {
         let updated_rows: Arc<AtomicI64> = Arc::new(AtomicI64::new(0));
         let inserted_rows: Arc<AtomicI64> = Arc::new(AtomicI64::new(0));
 
+        // `Count` metrics that surface in `EXPLAIN ANALYZE` as
+        // `metrics=[updated_rows=…, inserted_rows=…, deleted_rows=…]` on this
+        // node. Populated below after the write transaction commits.
+        let updated_rows_metric: Count =
+            MetricBuilder::new(&self.metrics).counter("updated_rows", partition);
+        let inserted_rows_metric: Count =
+            MetricBuilder::new(&self.metrics).counter("inserted_rows", partition);
+        let deleted_rows_metric: Count =
+            MetricBuilder::new(&self.metrics).counter("deleted_rows", partition);
+
         let coalesce = CoalescePartitionsExec::new(self.input.clone());
 
         // Filter out rows whoose __data_file_path doesn't have a matching row
@@ -163,6 +187,9 @@ impl ExecutionPlan for MergeIntoCOWSinkExec {
             let schema = schema.clone();
             let updated_rows = Arc::clone(&updated_rows);
             let inserted_rows = Arc::clone(&inserted_rows);
+            let updated_rows_metric = updated_rows_metric.clone();
+            let inserted_rows_metric = inserted_rows_metric.clone();
+            let deleted_rows_metric = deleted_rows_metric.clone();
             let projected_schema = count_and_project_stream.projected_schema();
             let batches: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
                 projected_schema,
@@ -221,6 +248,13 @@ impl ExecutionPlan for MergeIntoCOWSinkExec {
                 let inserted = inserted_rows.load(Ordering::Relaxed);
                 // MERGE DELETE is not supported yet
                 let deleted = 0i64;
+
+                // Publish per-clause counts to the `MetricsSet` so
+                // `EXPLAIN ANALYZE` shows them on the MergeIntoSinkExec line.
+                // Rely on `try_from` so huge row counts fall back cleanly.
+                updated_rows_metric.add(usize::try_from(updated).unwrap_or(usize::MAX));
+                inserted_rows_metric.add(usize::try_from(inserted).unwrap_or(usize::MAX));
+                deleted_rows_metric.add(usize::try_from(deleted).unwrap_or(usize::MAX));
 
                 let arrays = schema
                     .fields()

--- a/crates/executor/src/datafusion/physical_plan/merge.rs
+++ b/crates/executor/src/datafusion/physical_plan/merge.rs
@@ -689,7 +689,13 @@ impl Stream for MergeCOWFilterStream {
                             .push(filtered_batch);
                     }
 
-                    if matching_data_and_manifest_files.is_empty() {
+                    // Only take the fast paths if the current batch references no target file
+                    // that will be (or has been) overwritten. Otherwise the full filter path
+                    // below is required so target rows belonging to `all_matching_data_files`
+                    // are re-emitted into the rewritten data file.
+                    if matching_data_and_manifest_files.is_empty()
+                        && all_matching_data_files.is_empty()
+                    {
                         // Return early if all rows only come from source
                         if matching_data_file_array.len() == source_exists_array.len() {
                             return Poll::Ready(Some(Ok(batch)));
@@ -1243,5 +1249,25 @@ mod tests {
         source_target_source_matching,
         &[(0, 2), (0, 1), (0, 6), (0, 5)],
         60
+    );
+    // Regression test for https://github.com/Embucket/embucket/issues/128
+    //
+    // If a target file has been seen as "matching" in an earlier batch and a subsequent
+    // batch contains only target rows (no `__source_exists` = true rows) for that same
+    // file, the rows in the later batch must still be passed through the filter so they
+    // land in the rewritten data file. Previously the "no matches, no source" fast path
+    // dropped them, causing silent data loss during `MERGE INTO` on unsorted inputs.
+    test_merge_cow_filter_stream!(matching_then_target, &[(0, 4), (0, 1)], 20);
+    test_merge_cow_filter_stream!(
+        matching_then_target_then_matching,
+        &[(0, 4), (0, 1), (0, 4)],
+        30
+    );
+    // Mixed scenario: several target-only batches arriving AFTER the target file has
+    // been matched.
+    test_merge_cow_filter_stream!(
+        matching_then_multiple_target_batches,
+        &[(0, 4), (0, 1), (0, 1), (0, 1)],
+        40
     );
 }

--- a/crates/executor/src/query.rs
+++ b/crates/executor/src/query.rs
@@ -57,7 +57,7 @@ use datafusion::sql::statement::object_name_to_string;
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::{
     Column, DFSchema, DataFusionError, ParamValues, ResolvedTableReference, SchemaReference,
-    TableReference, plan_datafusion_err,
+    TableReference, ToDFSchema, plan_datafusion_err,
 };
 use datafusion_expr::conditional_expressions::CaseBuilder;
 use datafusion_expr::logical_plan::dml::{DmlStatement, InsertOp, WriteOp};
@@ -464,6 +464,50 @@ impl UserQuery {
             }
         } else if let DFStatement::CreateExternalTable(cetable) = statement {
             return Box::pin(self.create_external_table_query(cetable)).await;
+        } else if let DFStatement::Explain(explain) = &statement {
+            // DataFusion's default planner rejects `EXPLAIN MERGE INTO ...` as
+            // "Unsupported SQL statement: MERGE INTO" because MERGE has its
+            // own Embucket-side planner (`merge_query`). Intercept the case
+            // where the inner statement is a MERGE: build the merge logical
+            // plan ourselves, then wrap it in the equivalent `LogicalPlan::Explain`
+            // / `LogicalPlan::Analyze` that DataFusion's SQL path would have
+            // produced. This lets callers actually inspect the plan and see
+            // physical-level metrics via `EXPLAIN ANALYZE MERGE`.
+            if let DFStatement::Statement(inner) = explain.statement.as_ref() {
+                if matches!(inner.as_ref(), Statement::Merge { .. }) {
+                    let analyze = explain.analyze;
+                    let verbose = explain.verbose;
+                    let format = explain.format.clone();
+                    let merge_stmt = (**inner).clone();
+                    let merge_plan = Box::pin(self.merge_to_logical_plan(merge_stmt)).await?;
+                    let merge_plan = Arc::new(merge_plan);
+                    let schema = datafusion_expr::LogicalPlan::explain_schema()
+                        .to_dfschema_ref()
+                        .context(ex_error::DataFusionSnafu)?;
+                    let wrapped = if analyze {
+                        LogicalPlan::Analyze(datafusion_expr::logical_plan::Analyze {
+                            verbose,
+                            input: merge_plan,
+                            schema,
+                        })
+                    } else {
+                        let explain_format = match format.as_deref() {
+                            Some(f) => datafusion_expr::logical_plan::ExplainFormat::from_str(f)
+                                .unwrap_or(datafusion_expr::logical_plan::ExplainFormat::Indent),
+                            None => datafusion_expr::logical_plan::ExplainFormat::Indent,
+                        };
+                        LogicalPlan::Explain(datafusion_expr::logical_plan::Explain {
+                            verbose,
+                            explain_format,
+                            plan: merge_plan,
+                            stringified_plans: vec![],
+                            schema,
+                            logical_optimization_succeeded: false,
+                        })
+                    };
+                    return self.execute_logical_plan(wrapped).await;
+                }
+            }
         }
         self.execute_sql(&self.query).await
     }
@@ -1283,9 +1327,23 @@ impl UserQuery {
         }
     }
 
-    #[allow(clippy::too_many_lines)]
     #[instrument(name = "UserQuery::merge_query", level = "trace", skip(self), err)]
     pub async fn merge_query(&self, statement: Statement) -> Result<QueryResult> {
+        let plan = self.merge_to_logical_plan(statement).await?;
+        self.execute_logical_plan(plan).await
+    }
+
+    /// Builds the logical plan for a `MERGE INTO` statement without executing
+    /// it. Shared between `merge_query` (which runs the plan) and the
+    /// `DFStatement::Explain` routing in `execute` (which wraps it in
+    /// `LogicalPlan::Explain` / `LogicalPlan::Analyze` so callers can see the
+    /// plan or live physical metrics without a separate SQL path).
+    #[allow(clippy::too_many_lines)]
+    #[instrument(name = "UserQuery::merge_to_logical_plan", level = "trace", skip(self), err)]
+    pub async fn merge_to_logical_plan(
+        &self,
+        statement: Statement,
+    ) -> Result<LogicalPlan> {
         let Statement::Merge {
             table: target,
             source,
@@ -1501,10 +1559,9 @@ impl UserQuery {
         )
         .context(ex_error::DataFusionSnafu)?;
 
-        self.execute_logical_plan(LogicalPlan::Extension(Extension {
+        Ok(LogicalPlan::Extension(Extension {
             node: Arc::new(merge_into_plan),
         }))
-        .await
     }
 
     #[instrument(name = "UserQuery::create_database", level = "trace", skip(self), err)]

--- a/crates/executor/src/tests/sql/ddl/merge_into.rs
+++ b/crates/executor/src/tests/sql/ddl/merge_into.rs
@@ -1,5 +1,28 @@
 use crate::test_query;
 
+// Observability: `EXPLAIN MERGE INTO ...` must work. Before the routing
+// fix, Embucket rejected it with
+// "SQL compilation error: unsupported feature: Unsupported SQL statement:
+// MERGE INTO" because `execute()` never unwrapped
+// `DFStatement::Explain(..MERGE..)` and fell through to DataFusion's default
+// SQL path, which doesn't know about Embucket's MERGE planner.
+//
+// This test covers the plan shape only. `EXPLAIN ANALYZE MERGE` is
+// exercised end-to-end against the deployed Lambda — its output contains
+// per-run metric values whose width varies the formatted-table column
+// padding, which is too unstable for an insta snapshot.
+test_query!(
+    merge_into_explain,
+    "EXPLAIN MERGE INTO merge_target USING merge_source ON merge_target.id = merge_source.id WHEN MATCHED THEN UPDATE SET merge_target.description = merge_source.description",
+    setup_queries = [
+        "CREATE TABLE embucket.public.merge_target (ID INTEGER, description VARCHAR)",
+        "CREATE TABLE embucket.public.merge_source (ID INTEGER, description VARCHAR)",
+        "INSERT INTO embucket.public.merge_target VALUES (1, 'existing row')",
+        "INSERT INTO embucket.public.merge_source VALUES (1, 'updated row')",
+    ],
+    snapshot_path = "merge_into"
+);
+
 test_query!(
     merge_into_only_update,
     "SELECT count(CASE WHEN description = 'updated row' THEN 1 ELSE NULL END) updated, count(CASE WHEN description = 'existing row' THEN 1 ELSE NULL END) existing FROM embucket.public.merge_target",

--- a/crates/executor/src/tests/sql/ddl/merge_into.rs
+++ b/crates/executor/src/tests/sql/ddl/merge_into.rs
@@ -322,3 +322,25 @@ test_query!(
     ],
     snapshot_path = "merge_into"
 );
+
+// Regression test for https://github.com/Embucket/embucket/issues/128.
+//
+// Target is one data file with many rows; source is a mix of updates (matches) and
+// inserts (no match), and the target rows of the join land in the filter stream in
+// batches where some contain source_exists=true rows and some only contain target
+// rows. Previously the "no matches, no source" fast path would silently drop the
+// target-only batches for a file that had already been marked as matching in an
+// earlier batch, causing the final row count to be less than the expected
+// (target_rows + new_source_rows). This test asserts that no target row is lost.
+test_query!(
+    merge_into_mixed_unsorted_multi_row_no_data_loss,
+    "SELECT COUNT(*) as total_rows, COUNT(CASE WHEN description = 'updated row' THEN 1 END) as updated_rows, COUNT(CASE WHEN description = 'original row' THEN 1 END) as preserved_rows, COUNT(CASE WHEN description = 'new row' THEN 1 END) as inserted_rows FROM embucket.public.merge_target",
+    setup_queries = [
+        "CREATE TABLE embucket.public.merge_target (id INTEGER, description VARCHAR)",
+        "CREATE TABLE embucket.public.merge_source (id INTEGER, description VARCHAR)",
+        "INSERT INTO embucket.public.merge_target VALUES (1, 'original row'), (2, 'original row'), (3, 'original row'), (4, 'original row'), (5, 'original row'), (6, 'original row'), (7, 'original row'), (8, 'original row'), (9, 'original row'), (10, 'original row')",
+        "INSERT INTO embucket.public.merge_source VALUES (3, 'updated row'), (7, 'updated row'), (11, 'new row'), (12, 'new row')",
+        "MERGE INTO merge_target t USING merge_source s ON t.id = s.id WHEN MATCHED THEN UPDATE SET t.description = s.description WHEN NOT MATCHED THEN INSERT (id, description) VALUES (s.id, s.description)",
+    ],
+    snapshot_path = "merge_into"
+);

--- a/crates/executor/src/tests/sql/ddl/snapshots/merge_into/query_merge_into_explain.snap
+++ b/crates/executor/src/tests/sql/ddl/snapshots/merge_into/query_merge_into_explain.snap
@@ -1,0 +1,34 @@
+---
+source: crates/executor/src/tests/sql/ddl/merge_into.rs
+description: "\"EXPLAIN MERGE INTO merge_target USING merge_source ON merge_target.id = merge_source.id WHEN MATCHED THEN UPDATE SET merge_target.description = merge_source.description\""
+info: "Setup queries: CREATE TABLE embucket.public.merge_target (ID INTEGER, description VARCHAR); CREATE TABLE embucket.public.merge_source (ID INTEGER, description VARCHAR); INSERT INTO embucket.public.merge_target VALUES (1, 'existing row'); INSERT INTO embucket.public.merge_source VALUES (1, 'updated row')"
+---
+Ok(
+    [
+        "+---------------+----------------------------------------------------------------------------------------------------------------------------------+",
+        "| plan_type     | plan                                                                                                    |",
+        "+---------------+----------------------------------------------------------------------------------------------------------------------------------+",
+        "| logical_plan  | MergeIntoSink                                                                                                    |",
+        "|               |   Projection: embucket.public.merge_target.id, CASE WHEN __common_expr_1 THEN TRY_CAST(embucket.public.merge_source.description AS Utf8) ELSE embucket.public.merge_target.description END AS description, embucket.public.merge_target.__data_file_path, embucket.public.merge_target.__manifest_file_path, __target_exists, __source_exists, __common_expr_1 AS __merge_row_updated, Boolean(false) AS __merge_row_inserted |",
+        "|               |     Projection: __target_exists AND __source_exists AS __common_expr_1, embucket.public.merge_target.id, embucket.public.merge_target.description, embucket.public.merge_target.__data_file_path, embucket.public.merge_target.__manifest_file_path, __target_exists, embucket.public.merge_source.id, embucket.public.merge_source.description, __source_exists                                                              |",
+        "|               |       Full Join: embucket.public.merge_target.id = embucket.public.merge_source.id                                                                                                    |",
+        "|               |         Projection: embucket.public.merge_target.id, embucket.public.merge_target.description, embucket.public.merge_target.__data_file_path, embucket.public.merge_target.__manifest_file_path, Boolean(true) AS __target_exists                                                                                                    |",
+        "|               |           TableScan: embucket.public.merge_target                                                                                                    |",
+        "|               |         Projection: embucket.public.merge_source.id, embucket.public.merge_source.description, Boolean(true) AS __source_exists                                                                                                    |",
+        "|               |           TableScan: embucket.public.merge_source                                                                                                    |",
+        "| physical_plan | MergeIntoSinkExec                                                                                                    |",
+        "|               |   ProjectionExec: expr=[id@1 as id, CASE WHEN __common_expr_1@0 THEN description@7 ELSE description@2 END as description, __data_file_path@3 as __data_file_path, __manifest_file_path@4 as __manifest_file_path, __target_exists@5 as __target_exists, __source_exists@8 as __source_exists, __common_expr_1@0 as __merge_row_updated, false as __merge_row_inserted]                                                        |",
+        "|               |     ProjectionExec: expr=[__target_exists@4 AND __source_exists@7 as __common_expr_1, id@0 as id, description@1 as description, __data_file_path@2 as __data_file_path, __manifest_file_path@3 as __manifest_file_path, __target_exists@4 as __target_exists, id@5 as id, description@6 as description, __source_exists@7 as __source_exists]                                                                                 |",
+        "|               |       RepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=1                                                                                                    |",
+        "|               |         ProjectionExec: expr=[id@3 as id, description@4 as description, __data_file_path@5 as __data_file_path, __manifest_file_path@6 as __manifest_file_path, __target_exists@7 as __target_exists, id@0 as id, description@1 as description, __source_exists@2 as __source_exists]                                                                                                    |",
+        "|               |           CoalesceBatchesExec: target_batch_size=8192                                                                                                    |",
+        "|               |             CoalesceBatchesExec: target_batch_size=8192                                                                                                    |",
+        "|               |               HashJoinExec: mode=CollectLeft, join_type=Full, on=[(id@0, id@0)]                                                                                                    |",
+        "|               |                 ProjectionExec: expr=[id@0 as id, description@1 as description, true as __source_exists]                                                                                                    |",
+        "|               |                   DataSourceExec: file_groups={1 group: [[/[PATH]/testing/data/[HEX]/[UUID].parquet]]}, projection=[id, description], file_type=parquet                                                                                                    |",
+        "|               |                 ProjectionExec: expr=[id@0 as id, description@1 as description, __data_file_path@2 as __data_file_path, __manifest_file_path@3 as __manifest_file_path, true as __target_exists]                                                                                                    |",
+        "|               |                   DataSourceExec: file_groups={1 group: [[/[PATH]/testing/data/[HEX]/[UUID].parquet]]}, projection=[id, description, __data_file_path, __manifest_file_path], file_type=parquet                                                                                                    |",
+        "|               |                                                                                                    |",
+        "+---------------+----------------------------------------------------------------------------------------------------------------------------------+",
+    ],
+)

--- a/crates/executor/src/tests/sql/ddl/snapshots/merge_into/query_merge_into_mixed_unsorted_multi_row_no_data_loss.snap
+++ b/crates/executor/src/tests/sql/ddl/snapshots/merge_into/query_merge_into_mixed_unsorted_multi_row_no_data_loss.snap
@@ -1,0 +1,14 @@
+---
+source: crates/executor/src/tests/sql/ddl/merge_into.rs
+description: "\"SELECT COUNT(*) as total_rows, COUNT(CASE WHEN description = 'updated row' THEN 1 END) as updated_rows, COUNT(CASE WHEN description = 'original row' THEN 1 END) as preserved_rows, COUNT(CASE WHEN description = 'new row' THEN 1 END) as inserted_rows FROM embucket.public.merge_target\""
+info: "Setup queries: CREATE TABLE embucket.public.merge_target (id INTEGER, description VARCHAR); CREATE TABLE embucket.public.merge_source (id INTEGER, description VARCHAR); INSERT INTO embucket.public.merge_target VALUES (1, 'original row'), (2, 'original row'), (3, 'original row'), (4, 'original row'), (5, 'original row'), (6, 'original row'), (7, 'original row'), (8, 'original row'), (9, 'original row'), (10, 'original row'); INSERT INTO embucket.public.merge_source VALUES (3, 'updated row'), (7, 'updated row'), (11, 'new row'), (12, 'new row'); MERGE INTO merge_target t USING merge_source s ON t.id = s.id WHEN MATCHED THEN UPDATE SET t.description = s.description WHEN NOT MATCHED THEN INSERT (id, description) VALUES (s.id, s.description)"
+---
+Ok(
+    [
+        "+------------+--------------+----------------+---------------+",
+        "| total_rows | updated_rows | preserved_rows | inserted_rows |",
+        "+------------+--------------+----------------+---------------+",
+        "| 12         | 2            | 8              | 2             |",
+        "+------------+--------------+----------------+---------------+",
+    ],
+)


### PR DESCRIPTION
Four related Embucket MERGE-path fixes, all needed to make `MERGE INTO` correct, observable, and tunable on partitioned Iceberg targets.

## Changes

1. **`fix(custom_type_coercion)`** — `CustomTypeCoercionRewriter::analyze_internal` now falls back to `plan.schema()` when `plan.inputs()` is empty (leaf `TableScan` case). Without this, the target filter that `merge_query` injects via `LogicalPlanBuilder::scan_with_filters` against a partitioned `DataFusionTable` failed the analyzer with `Schema error: No field named <col>`. Unblocks source-side partition-hint pruning.

2. **`feat(merge): EXPLAIN routing`** — Embucket has its own MERGE planner, so DataFusion rejected `EXPLAIN MERGE INTO …` with `Unsupported SQL statement`. Split `merge_query` into a pure plan-builder + a thin executing wrapper; in `execute()`, when the parsed statement is `Explain(MergeInto)`, build the plan and wrap it in `LogicalPlan::Explain` / `LogicalPlan::Analyze` to match DataFusion's `explain_to_plan`. Adds an `EXPLAIN MERGE` snapshot test (22 existing merge_into tests stay green).

3. **`feat(merge): MetricsSet`** — surface `updated_rows` / `inserted_rows` / `deleted_rows` as per-clause counters on `MergeIntoCOWSinkExec` so `EXPLAIN ANALYZE MERGE INTO …` now shows them alongside child `DataSourceExec` scan metrics (`bytes_scanned`, `files_ranges_pruned_statistics`, `row_groups_pruned_statistics`, `pushdown_rows_pruned`, `output_rows`, `elapsed_compute`).

4. **`fix(merge): preserve target rows`** — fixes #128. A stale fast-path guard in `MergeCOWFilterStream::poll_next` short-circuited on `matching_data_and_manifest_files.is_empty()` alone, without checking `all_matching_data_files`. So when a target file had been seen as matching in an earlier batch and a later batch contained only target rows for that file, the rows in the later batch were silently dropped (the COW commit then overwrote the original file with the partial result). Six-line guard tightening: also require `all_matching_data_files` to be empty before short-circuiting. Counters were always correct; only the committed parquet was short. Sorting either input by the join key masked the bug, which is why it took finding to surface.

## Why all four together

(1) and (2)+(3) work in tandem: with (1) alone the source-side filter is pushed into the target `TableScan` as a `partial_filter` and the MERGE commits the right rows, but the prune is invisible from outside. (2)+(3) make `EXPLAIN MERGE` and `EXPLAIN ANALYZE MERGE` work end-to-end and surface the prune metrics, so an operator can verify and tune the pruning. (4) is the silent-data-loss bug those tools exposed once the bigger MERGE workloads started running on real partitioned Iceberg tables.

## Tests

- 3 new unit tests on `MergeCOWFilterStream` covering the matching-then-target-only patterns (fail on `main`, pass here)
- 1 new SQL snapshot test `merge_into_mixed_unsorted_multi_row_no_data_loss` (10-row target × 4-row source, asserts no row loss)
- 1 new SQL snapshot test for `EXPLAIN MERGE` (`EXPLAIN ANALYZE` is exercised end-to-end against a Lambda but intentionally not snapshot-tested — its formatted-table widths vary per run)
- `cargo test -p executor`: **362 passed, 0 failed**

## End-to-end validation against deployed Embucket Lambda

**#128 isolated repro** — 5 consecutive runs against a freshly-deployed lambda built from this branch, all `loss=0` deterministic:

```
target=2101659 source=2103638 merge=[1052088, 1051550] post=3153747 expected=3153747 loss=0
target=2101659 source=2103638 merge=[1052088, 1051550] post=3153747 expected=3153747 loss=0
target=2101659 source=2103638 merge=[1052088, 1051550] post=3153747 expected=3153747 loss=0
target=2101659 source=2103638 merge=[1052088, 1051550] post=3153747 expected=3153747 loss=0
target=2101659 source=2103638 merge=[1052088, 1051550] post=3153747 expected=3153747 loss=0
```

12.6 M target × 6.3 M source: `post=14697755 expected=14697755 loss=0`.

**dbt-snowplow-web stretch validation** — fresh seed + R1–R5 of `loop_dbt.py`, complete. `user_mapping` Δ is the strongest MERGE-correctness signal (its source CTE feeds straight from the buggy MERGE on `lifecycle_manifest`):

| Round | dbt | Δ user_mapping (this PR) | Δ user_mapping (pre-fix) |
|---:|---:|---:|---:|
| 1 | 280.9 s | +1,702,223 | +1,702,223 |
| 2 | 381.1 s | +1,699,998 | +1,699,998 |
| 3 | 386.0 s | **+1,700,804 ✓** | +690,664 ❌ |
| 4 | 390.3 s | **+1,699,815 ✓** | +186,950 ❌ |
| 5 | 385.5 s | **+1,699,577 ✓** | +611,373 ❌ |
| **total after R5** | | **10,204,627** | 6,593,418 |

R3 is where the bug first manifested in the original buggy run. With the fix, R3, R4, and R5 each deliver the full ~+1.7 M rows that match the day-partitioned baseline. The fix recovered **3,611,209 rows** of `user_mapping` data (≈55% of the post-fix total) that the buggy MERGE was silently dropping over 5 rounds.

**Source-side partition pruning** end-to-end: `MERGE INTO atomic.events_hooli_tiny USING atomic.events_hooli_ident ON t.event_id = s.event_id WHEN MATCHED THEN UPDATE …` — previously failed with `custom_type_coercion / Schema error: No field named event_name`, now returns 100 matched rows and commits. The companion `EXPLAIN ANALYZE MERGE INTO …` emits the target `TableScan`'s `partial_filters=[event_name = Utf8("ad_start_event")]` and full `DataSourceExec` scan-metrics block.

## Out of scope (separate follow-ups)

- **`MergeCOWFilterStream::not_matched_buffer` LRU eviction** — capacity is 2 on Lambda; doesn't fire in single-target-file repros but will silently evict any third-and-later concurrently-buffered file's rows. Worth its own issue with a 3+ data file repro.
- **Round-6 dbt SELECT-phase OOM** — independent of this PR. With the data-loss fix in place, `lifecycle_manifest` will now grow correctly and the model's `previous_sessions` LEFT JOIN OOMs the 9 GB Lambda pool around R6. Needs planner-level predicate pushdown or non-Lambda compute.

Companion to [Embucket/iceberg-rust#57](https://github.com/Embucket/iceberg-rust/pull/57). Closes #128.