### PR TITLE
Update iceberg-rust dependencies to latest commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3007,7 +3007,7 @@ dependencies = [
 [[package]]
 name = "datafusion_iceberg"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=af0532380770f55f23c783e555b4674cec743174#af0532380770f55f23c783e555b4674cec743174"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=8898408938dc31ef4e5e02c470a6b85294b12b4b#8898408938dc31ef4e5e02c470a6b85294b12b4b"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4466,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rest-catalog"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=af0532380770f55f23c783e555b4674cec743174#af0532380770f55f23c783e555b4674cec743174"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=8898408938dc31ef4e5e02c470a6b85294b12b4b#8898408938dc31ef4e5e02c470a6b85294b12b4b"
 dependencies = [
  "async-trait",
  "aws-sigv4 0.3.1",
@@ -4491,7 +4491,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=af0532380770f55f23c783e555b4674cec743174#af0532380770f55f23c783e555b4674cec743174"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=8898408938dc31ef4e5e02c470a6b85294b12b4b#8898408938dc31ef4e5e02c470a6b85294b12b4b"
 dependencies = [
  "apache-avro",
  "arrow 56.2.0",
@@ -4527,7 +4527,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust-spec"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=af0532380770f55f23c783e555b4674cec743174#af0532380770f55f23c783e555b4674cec743174"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=8898408938dc31ef4e5e02c470a6b85294b12b4b#8898408938dc31ef4e5e02c470a6b85294b12b4b"
 dependencies = [
  "apache-avro",
  "arrow-schema 56.2.0",
@@ -4552,7 +4552,7 @@ dependencies = [
 [[package]]
 name = "iceberg-s3tables-catalog"
 version = "0.9.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=af0532380770f55f23c783e555b4674cec743174#af0532380770f55f23c783e555b4674cec743174"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=8898408938dc31ef4e5e02c470a6b85294b12b4b#8898408938dc31ef4e5e02c470a6b85294b12b4b"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6123,7 +6123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.111",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,15 +49,15 @@ datafusion-expr = { version = "50.0.0" }
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "439cbd2282504c3ffaf262f1ffdb530a0fb1a151" }
 datafusion-macros = { version = "50.0.0" }
 datafusion-physical-plan = { version = "50.0.0" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "af0532380770f55f23c783e555b4674cec743174" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "8898408938dc31ef4e5e02c470a6b85294b12b4b" }
 futures = { version = "0.3" }
 http = "1.2"
 http-body-util = "0.1.0"
 iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev="7a5ad1fcaf00d4638857812bab788105f6c60573"}
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "af0532380770f55f23c783e555b4674cec743174" }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "af0532380770f55f23c783e555b4674cec743174" }
-iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "af0532380770f55f23c783e555b4674cec743174" }
-iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "af0532380770f55f23c783e555b4674cec743174" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "8898408938dc31ef4e5e02c470a6b85294b12b4b" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "8898408938dc31ef4e5e02c470a6b85294b12b4b" }
+iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "8898408938dc31ef4e5e02c470a6b85294b12b4b" }
+iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "8898408938dc31ef4e5e02c470a6b85294b12b4b" }
 indexmap = "2.7.1"
 jsonwebtoken = "9.3.1"
 lazy_static = { version = "1.5" }


### PR DESCRIPTION
## Summary
Updates all Embucket iceberg-rust fork dependencies to a newer commit revision.

## Changes
- Updated `datafusion_iceberg` dependency from `af05323` to `8898408`
- Updated `iceberg-rest-catalog` dependency from `af05323` to `8898408`
- Updated `iceberg-rust` dependency from `af05323` to `8898408`
- Updated `iceberg-rust-spec` dependency from `af05323` to `8898408`
- Updated `iceberg-s3tables-catalog` dependency from `af05323` to `8898408`

All dependencies point to the same Embucket iceberg-rust fork repository and are now synchronized to the same commit hash.

https://claude.ai/code/session_016bRKCui5D6eJfkNiDJ8vs9